### PR TITLE
27 simplify process to create releases of java services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-ARG JAR_FILE=actionexportersvc-*.jar
 FROM openjdk:8-jre
 
 VOLUME /tmp
-ARG JAR_FILE
+ARG JAR_FILE=actionexportersvc-*.jar
 COPY target/$JAR_FILE /opt/actionexportersvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/actionexportersvc.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
+ARG JAR_FILE=actionexportersvc-*.jar
 FROM openjdk:8-jre
 
 VOLUME /tmp
-COPY target/actionexportersvc-*.jar /opt/actionexportersvc.jar
+ARG JAR_FILE
+COPY target/$JAR_FILE /opt/actionexportersvc.jar
 
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/actionexportersvc.jar" ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>uk.gov.ons.ctp.product</groupId>
   <artifactId>actionexportersvc</artifactId>
   <version>10.49.1-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -15,11 +14,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-  <!-- Inherit parent BOM to control versions of dependencies and plugin version & config -->
   <parent>
     <groupId>uk.gov.ons.ctp.product</groupId>
     <artifactId>rm-common-config</artifactId>
-    <version>10.49.1</version>
+    <version>10.49.8</version>
   </parent>
 
   <dependencies>
@@ -178,9 +176,9 @@
   </dependencies>
 
   <scm>
-    <connection>scm:git:git@github.com:ONSdigital/rm-actionexporter-service.git</connection>
-    <developerConnection>scm:git:git@github.com:ONSdigital/rm-actionexporter-service.git</developerConnection>
-    <url>git@github.com:ONSdigital/rm-actionexporter-service.git</url>
+    <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
+    <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
+    <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
   </scm>
 
   <build>
@@ -229,8 +227,10 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <finalName>docker-info-${project.artifactId}</finalName>
               <repository>sdcplatform/${project.artifactId}</repository>
+              <buildArgs>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+              </buildArgs>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.1-SNAPSHOT</version>
+  <version>10.49.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>


### PR DESCRIPTION
## What is it
These changes are driven to allow us to release artifacts in a much simpler way. Currently we have a bunch of shell scripts that we maintain to do releases when this is a core part of maven to be able to bump version, create tags and deploy artifacts.

* Bump versions and remove snapshot 
Release 13 was done on a branch where the version was incremented. The version change hasn't made it's way back into master yet so this change skips that version. We are also removing the snapshot versions.

* Using optional dockerfile buildArgs
We have been fighting with the `COPY target/actionexportersvc*.jar` syntax when
there is  more that one samplesvc*.jar file that  exists in the target
directory. Thought it was fixed by the docker info change but the same
issue occurs when doing a release because it builds the samplesvc-sources.jar.
This change makes the dockerfile JAR_FILE arg optional to allow the maven
build to provide the full name including version.

The output of the artifacts/tags are:
* A tag called `${project.artifactId}-${project.version}
* 3 artifacts called `${project.artifactId}-${project.version}-${classifier}.jar
* A version of the pom.xml in artifactory in the format `${project.artifactId}-${project.version}.pom`
## Testing
1. Checkout branch
2.  `export ARTIFACTORY_PASSWORD=$REAL_PASSWORD`
3. `mvn -B release:prepare release:perform -Darguments="-Dmaven.javadoc.skip=true"`