### PR TITLE
Us012 fixed data

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/repository/ActionRequestRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/repository/ActionRequestRepository.java
@@ -44,7 +44,7 @@ public interface ActionRequestRepository extends BaseRepository<ActionRequestIns
    * @return List ActionRequests not sent to external services previously for
    *         actionType.
    */
-  List<ActionRequestInstruction> findByDateSentIsNullAndActionTypeAndExerciseRef(String actionType, String exerciseRef);
+  List<ActionRequestInstruction> findByDateSentIsNullAndActionTypeAndExerciseRefAndSurveyRef(String actionType, String exerciseRef, String surveyRef);
 
   /**
    * Retrieve a list of actionTypes

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
@@ -194,8 +194,8 @@ public class ExportScheduler implements HealthIndicator {
               List<ActionRequestInstruction> requests = actionRequestService
                   .findByDateSentIsNullAndActionTypeAndExerciseRef(templateMapping.getActionType(), surveyRefExerciseRefTuple.getExerciseRef(), surveyRefExerciseRefTuple.getSurveyRef());
               if (requests.isEmpty()) {
-                log.info("No requests for actionType {}, exerciseRef {} to process", templateMapping.getActionType(),
-                    surveyRefAndexerciseRef);
+                log.info("No requests for actionType {}, surveyRef {} exerciseRef {} to process", templateMapping.getActionType(),
+                		surveyRefExerciseRefTuple.getExerciseRef(), surveyRefExerciseRefTuple.getSurveyRef());
               } else {
                 try {
                   transformationService.processActionRequests(message, requests);

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
@@ -192,7 +192,7 @@ public class ExportScheduler implements HealthIndicator {
             templatemappings.forEach((templateMapping) -> {
 
               List<ActionRequestInstruction> requests = actionRequestService
-                  .findByDateSentIsNullAndActionTypeAndExerciseRef(templateMapping.getActionType(), surveyRefAndexerciseRef);
+                  .findByDateSentIsNullAndActionTypeAndExerciseRef(templateMapping.getActionType(), surveyRefExerciseRefTuple.getExerciseRef(), surveyRefExerciseRefTuple.getSurveyRef());
               if (requests.isEmpty()) {
                 log.info("No requests for actionType {}, exerciseRef {} to process", templateMapping.getActionType(),
                     surveyRefAndexerciseRef);

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionRequestService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionRequestService.java
@@ -44,7 +44,7 @@ public interface ActionRequestService {
    * @return List of ActionRequests not sent to external services previously for
    *         actionType, exerciseRef.
    */
-  List<ActionRequestInstruction> findByDateSentIsNullAndActionTypeAndExerciseRef(String actionType, String exerciseRef);
+  List<ActionRequestInstruction> findByDateSentIsNullAndActionTypeAndExerciseRef(String actionType, String exerciseRef, String surveyRef);
 
   /**
    * Return a list of distinct exerciseRefs

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/impl/ActionRequestServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/impl/ActionRequestServiceImpl.java
@@ -41,8 +41,8 @@ public class ActionRequestServiceImpl implements ActionRequestService {
 
   @Override
   public List<ActionRequestInstruction> findByDateSentIsNullAndActionTypeAndExerciseRef(String actionType,
-      String exerciseRef) {
-    return repository.findByDateSentIsNullAndActionTypeAndExerciseRef(actionType, exerciseRef);
+      String exerciseRef, String surveyRef) {
+    return repository.findByDateSentIsNullAndActionTypeAndExerciseRefAndSurveyRef(actionType, exerciseRef, surveyRef);
   }
 
   @Override


### PR DESCRIPTION
This fixes the query where actionexporter.actionrequest.exercise_ref is in the correct format e.g 201712 and not the 221_201712 format used for BRES.