### PR TITLE
Updating actionsvc-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
     <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
-    <tag>actionexportersvc-10.49.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.7-SNAPSHOT</version>
+  <version>10.49.8-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>
@@ -179,7 +179,7 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
     <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
-    <tag>HEAD</tag>
+    <tag>actionexportersvc-10.49.6</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.5</version>
+      <version>10.49.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- Changing the actionsvc-api dependency to include `userDescription` for
request instructions.

- Making these changes in a feature branch from tag actionexportersvc-10.49.6 (f0146dee271145d656818f07eb02620b50a0f6d5). This is to avoid deploying actionexportersvc version 10.49.7 in Prod.

- Updating the POM version to `10.49.8-SNAPSHOT`.

- Setting SCM Tag back to `HEAD`.

- Tested this locally.