### PR TITLE
Remove host from manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,6 @@
 applications:
 - name: actionexportersvc
   instances: 1
-  host: actionexportersvc
   memory: 1024M
   health-check-type: none
   path: target/actionexportersvc.jar


### PR DESCRIPTION
The host will default to the app name. As long as the app name is named
what you want it to be when CF push is ran the host will be the same. As
the manifest file defines the app name it will fallback to that if not
set.

See https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html