### PR TITLE
Add instructions for settings up maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,15 @@ See [API.md](https://github.com/ONSdigital/rm-actionexporter-service/blob/master
 
 ## Copyright
 Copyright (C) 2017 Crown Copyright (Office for National Statistics)
-## To build
-./mvnw clean install
 
+## Running
 
-## To run
-    - Prerequisites:
-        - Start MongoDB:
-            - sudo mongod --dbpath /var/lib/mongodb
-        - Start ActiveMQ:
-            - sudo /sbin/service rabbitmq-server stop
-            - cd /opt/apache-activemq-5.13.3/bin
-            - ./activemq console
+There are two ways of running this service
 
-    - To start with default credentials:
-        ./mvnw spring-boot:run
-
-    - To start with specific credentials:
-        ./mvnw spring-boot:run -Dsecurity.user.name=tiptop -Dsecurity.user.password=override
-
-
-## To test
-See curlTests.tx under /test/resources
+* The easiest way is via docker (https://github.com/ONSdigital/ras-rm-docker-dev)
+* Alternatively running the service up in isolation
+    ```bash
+    cp .maven.settings.xml ~/.m2/settings.xml  # This only needs to be done once to set up mavens settings file
+    mvn clean install
+    mvn spring-boot:run
+    ```


### PR DESCRIPTION
## Background
Developers who have recently started working on this project have not been aware that they need to update their local ~/.m2/settings.xml file to be able to build the project.

The service depends on artifacts that are being stored in artifactory.
The instructions that have been added describe how to configure maven
locally for building the project.

## What has changed
Added documentation describing how to start service

## How to review
Check instructions to start service are correct