### PR TITLE
Sts008 receive notification letter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2'
 
 services:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  postgres:
+    container_name: postgres-actionex
+    image: sdcplatform/ras-rm-docker-postgres
+    ports:
+     - "16432:5432"
+
+  sftp:
+    container_name: sftp-actionex
+    image: atmoz/sftp
+    volumes:
+        - ~/Documents/sftp:/home/centos/Documents/sftp
+    ports:
+        - "1122:22"
+    command: centos:JLibV2&XD,:1001
+
+  rabbitmq:
+    container_name: rabbitmq-actionex
+    image: rabbitmq:3.6.10-management
+    ports:
+      - "7672:5672"
+      - "26671:15671"
+      - "26672:15672"
+
+  redis:
+    container_name: redis-actionex
+    image: redis:3.2.9
+    ports:
+     - "17379:6379"

--- a/pom.xml
+++ b/pom.xml
@@ -248,10 +248,6 @@
               <goal>verify</goal>
             </goals>
             <phase>integration-test</phase>
-            <configuration>
-              <!-- rerun tests because schema isn't create successfully first time -->
-              <rerunFailingTestsCount>2</rerunFailingTestsCount>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.common</groupId>
       <artifactId>framework</artifactId>
-      <version>10.49.8</version>
+      <version>10.49.12</version>
     </dependency>
 
     <dependency>
@@ -169,6 +169,26 @@
     </dependency>
 
     <dependency>
+      <groupId>com.mashape.unirest</groupId>
+      <artifactId>unirest-java</artifactId>
+      <version>1.4.9</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>net.sourceforge.cobertura</groupId>
       <artifactId>cobertura</artifactId>
     </dependency>
@@ -218,6 +238,24 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.18.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <!-- rerun tests because schema isn't create successfully first time -->
+              <rerunFailingTestsCount>2</rerunFailingTestsCount>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>
         <version>1.3.4</version>
@@ -232,6 +270,63 @@
               <buildArgs>
                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
               </buildArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.23.0</version>
+        <executions>
+          <execution>
+            <id>pre-stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>start</id>
+            <goals>
+              <goal>start</goal>
+            </goals>
+            <configuration>
+              <showLogs>false</showLogs>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <goals>
+              <goal>stop</goal>
+            </goals>
+            <configuration>
+              <images>
+                <image>
+                  <external>
+                    <type>compose</type>
+                    <basedir>${project.basedir}</basedir>
+                  </external>
+                </image>
+              </images>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.9-SNAPSHOT</version>
+  <version>10.49.9</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>
@@ -179,7 +179,7 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
     <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
-    <tag>actionexportersvc-10.49.8</tag>
+    <tag>actionexportersvc-10.49.9</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.9</version>
+  <version>10.49.10-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>
@@ -179,7 +179,7 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
     <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
-    <tag>actionexportersvc-10.49.9</tag>
+    <tag>actionexportersvc-10.49.8</tag>
   </scm>
 
   <build>

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
@@ -1,10 +1,10 @@
 package uk.gov.ons.ctp.response.action.export.config;
 
+import lombok.Data;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import lombok.Data;
+import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
 
 /**
  * The apps main holder for centralized config read from application.yml or env
@@ -16,6 +16,7 @@ import lombok.Data;
 @ConfigurationProperties
 @Data
 public class AppConfig {
+  private Rabbitmq rabbitmq;
   private ExportSchedule exportSchedule;
   private DataGrid dataGrid;
   private SwaggerSettings swaggerSettings;

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/impl/SftpServicePublisherImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/impl/SftpServicePublisherImpl.java
@@ -1,5 +1,27 @@
 package uk.gov.ons.ctp.response.action.export.message.impl;
 
+import com.google.common.collect.Lists;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.annotation.MessageEndpoint;
+import org.springframework.integration.annotation.Publisher;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.file.FileHeaders;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.messaging.support.GenericMessage;
+import uk.gov.ons.ctp.common.time.DateTimeUtil;
+import uk.gov.ons.ctp.response.action.export.domain.ExportReport;
+import uk.gov.ons.ctp.response.action.export.message.ActionFeedbackPublisher;
+import uk.gov.ons.ctp.response.action.export.message.SftpServicePublisher;
+import uk.gov.ons.ctp.response.action.export.scheduled.ExportInfo;
+import uk.gov.ons.ctp.response.action.export.service.ActionRequestService;
+import uk.gov.ons.ctp.response.action.export.service.ExportReportService;
+import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
+import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
+
 import java.io.ByteArrayOutputStream;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -7,31 +29,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.integration.annotation.MessageEndpoint;
-import org.springframework.integration.annotation.Publisher;
-import org.springframework.integration.annotation.ServiceActivator;
-import org.springframework.integration.file.FileHeaders;
-import org.springframework.messaging.MessageHeaders;
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.messaging.support.GenericMessage;
-import org.springframework.messaging.MessagingException;
-
-import com.google.common.collect.Lists;
-
-import lombok.extern.slf4j.Slf4j;
-import uk.gov.ons.ctp.common.time.DateTimeUtil;
-import uk.gov.ons.ctp.response.action.export.domain.ExportReport;
-import uk.gov.ons.ctp.response.action.export.message.ActionFeedbackPublisher;
-import uk.gov.ons.ctp.response.action.export.message.EventPublisher;
-import uk.gov.ons.ctp.response.action.export.message.SftpServicePublisher;
-import uk.gov.ons.ctp.response.action.export.scheduled.ExportInfo;
-import uk.gov.ons.ctp.response.action.export.service.ActionRequestService;
-import uk.gov.ons.ctp.response.action.export.service.ExportReportService;
-import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
-import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
 
 /**
  * Service implementation responsible for publishing transformed ActionRequests
@@ -112,7 +109,7 @@ public class SftpServicePublisherImpl implements SftpServicePublisher {
     MessageHeaders headers = ((MessagingException) message.getPayload()).getFailedMessage().getHeaders();
     String fileName = (String) headers.get(FileHeaders.REMOTE_FILE);
     List<String> actionList = (List<String>) headers.get(ACTION_LIST);
-    log.error("Sftp transfer failed for file {} for action requests {}", fileName, actionList);
+    log.error("Sftp transfer failed for file {} for action requests {}", fileName, actionList, message.getPayload());
     exportInfo.addOutcome(fileName + " transfer failed with " + Integer.toString(actionList.size()) + " requests.");
     ExportReport exportReport = new ExportReport(fileName, actionList.size(), DateTimeUtil.nowUTC(), false, false);
     exportReportService.save(exportReport);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,24 @@
+liquibase:
+  user: postgres
+  password: postgres
+  url: jdbc:postgresql://localhost:16432/postgres
+
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:16432/postgres
+    username: postgres
+    password: postgres
+    port: 16432
+
+sftp:
+  port: 1122
+  host: localhost
+  username: centos
+  password: "JLibV2&XD,"
+  directory: Documents/sftp/
+
+data-grid:
+  address: localhost:17379
+
+rabbitmq:
+  port: 7672

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -22,3 +22,6 @@ data-grid:
 
 rabbitmq:
   port: 7672
+
+export-schedule:
+  cron-expression: "* * * * * *"

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -17,3 +17,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.49.0/changelog.yml
+
+  - include:
+      file: database/changes/release-10.50.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
+++ b/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
@@ -1,5 +1,11 @@
-UPDATE actionexporter.template
-SET content = '<#list actionRequests as actionRequest>
-${(actionRequest.address.sampleUnitRef?trim)!}:${(actionRequest.iac?trim)!"null"}:${(actionRequest.caseGroupStatus)!"null"}:${(actionRequest.enrolmentStatus)!"null"}:${(actionRequest.respondentStatus)!"null"}:${(actionRequest.contact.forename?trim)!"null"}:${(actionRequest.contact.surname?trim)!"null"}:${(actionRequest.contact.emailAddress)!"null"}:${(actionRequest.region)!"null"}:${(actionRequest.caseRef)!"null"}
-</#list>'
-WHERE templatenamepk ='initialPrint'
+INSERT INTO actionexporter.template
+(templatenamepk, content, datemodified)
+VALUES('socialNotification', '<#list actionRequests as actionRequest>
+${(actionRequest.address.sampleUnitRef?trim)!}:' ||
+'${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.iac?trim)!"null"}:' ||
+'${(actionRequest.caseRef)!"null"}
+</#list>', '2018-06-12 11:29:45.226');

--- a/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
+++ b/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
@@ -1,0 +1,5 @@
+UPDATE actionexporter.template
+SET content = '<#list actionRequests as actionRequest>
+${(actionRequest.address.sampleUnitRef?trim)!}:${(actionRequest.iac?trim)!"null"}:${(actionRequest.caseGroupStatus)!"null"}:${(actionRequest.enrolmentStatus)!"null"}:${(actionRequest.respondentStatus)!"null"}:${(actionRequest.contact.forename?trim)!"null"}:${(actionRequest.contact.surname?trim)!"null"}:${(actionRequest.contact.emailAddress)!"null"}:${(actionRequest.region)!"null"}:${(actionRequest.caseRef)!"null"}
+</#list>'
+WHERE templatenamepk ='initialPrint'

--- a/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
+++ b/src/main/resources/database/changes/release-10.50.0/add_caseref_to_print_template.sql
@@ -1,11 +1,11 @@
 INSERT INTO actionexporter.template
 (templatenamepk, content, datemodified)
 VALUES('socialNotification', '<#list actionRequests as actionRequest>
-${(actionRequest.address.sampleUnitRef?trim)!}:' ||
-'${(actionRequest.address.line1?trim)!}:' ||
+${(actionRequest.address.line1?trim)!}:' ||
 '${(actionRequest.address.line2?trim)!}:' ||
 '${(actionRequest.address.postcode?trim)!}:' ||
 '${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
 '${(actionRequest.iac?trim)!"null"}:' ||
 '${(actionRequest.caseRef)!"null"}
 </#list>', '2018-06-12 11:29:45.226');

--- a/src/main/resources/database/changes/release-10.50.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.0/changelog.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.50.0
+      author: Emilio Ward
+      changes:
+        - sqlFile:
+            comment: Added social action types for template mapping
+            path: update_template_mapping_for_social.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+
+  - changeSet:
+      id: 10.50.0
+      author: Emilio Ward
+      changes:
+        - sqlFile:
+            comment: Added social action types for template mapping
+            path: add_caseref_to_print_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-10.50.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.0/changelog.yml
@@ -11,11 +11,11 @@ databaseChangeLog:
             splitStatements: false
 
   - changeSet:
-      id: 10.50.0
+      id: 10.50.0-2
       author: Emilio Ward
       changes:
         - sqlFile:
-            comment: Added social action types for template mapping
+            comment: Added caseRef to print template
             path: add_caseref_to_print_template.sql
             relativeToChangelogFile: true
             splitStatements: false

--- a/src/main/resources/database/changes/release-10.50.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.0/changelog.yml
@@ -2,20 +2,20 @@ databaseChangeLog:
 
   - changeSet:
       id: 10.50.0
-      author: Emilio Ward
+      author: Emilio Ward, Adam Hawtin
       changes:
         - sqlFile:
-            comment: Added social action types for template mapping
-            path: update_template_mapping_for_social.sql
+            comment: Added caseRef to print template
+            path: add_caseref_to_print_template.sql
             relativeToChangelogFile: true
             splitStatements: false
 
   - changeSet:
       id: 10.50.0-2
-      author: Emilio Ward
+      author: Emilio Ward, Adam Hawtin
       changes:
         - sqlFile:
-            comment: Added caseRef to print template
-            path: add_caseref_to_print_template.sql
+            comment: Added social action types for template mapping
+            path: update_template_mapping_for_social.sql
             relativeToChangelogFile: true
             splitStatements: false

--- a/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
+++ b/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
@@ -1,0 +1,5 @@
+INSERT INTO actionexporter.templatemapping (actiontypenamepk, filenameprefix)
+VALUES
+(SOCIALNOT, SOCIALNOT),
+(SOCIALREM, SOCIALREM),
+(SOCIALSNE, SOCIALSNE);

--- a/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
+++ b/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
@@ -1,5 +1,5 @@
-INSERT INTO actionexporter.templatemapping (actiontypenamepk, filenameprefix)
+INSERT INTO actionexporter.templatemapping
 VALUES
-(SOCIALNOT, SOCIALNOT),
-(SOCIALREM, SOCIALREM),
-(SOCIALSNE, SOCIALSNE);
+('SOCIALNOT','initialPrint', 'SOCIALNOT', now()),
+('SOCIALREM', 'initialPrint', 'SOCIALREM', now()),
+('SOCIALSNE', 'initialPrint', 'SOCIALSNE', now());

--- a/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
+++ b/src/main/resources/database/changes/release-10.50.0/update_template_mapping_for_social.sql
@@ -1,5 +1,5 @@
 INSERT INTO actionexporter.templatemapping
 VALUES
-('SOCIALNOT','initialPrint', 'SOCIALNOT', now()),
-('SOCIALREM', 'initialPrint', 'SOCIALREM', now()),
-('SOCIALSNE', 'initialPrint', 'SOCIALSNE', now());
+('SOCIALNOT','socialNotification', 'SOCIALNOT', now()),
+('SOCIALREM', 'socialNotification', 'SOCIALREM', now()),
+('SOCIALSNE', 'socialNotification', 'SOCIALSNE', now());

--- a/src/main/resources/springintegration/broker.xml
+++ b/src/main/resources/springintegration/broker.xml
@@ -51,9 +51,8 @@
 	<!-- End of Queues -->
 
 	<!-- Start of Exchanges -->
-	
-	<rabbit:fanout-exchange name="event-message-outbound-exchange"></rabbit:fanout-exchange>
-	
+	<rabbit:fanout-exchange name="event-message-outbound-exchange"/>
+
 	<rabbit:direct-exchange name="action-outbound-exchange">
 		<rabbit:bindings>
 			<rabbit:binding queue="Action.Feedback" key="Action.Feedback.binding" />

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -1,0 +1,164 @@
+package uk.gov.ons.ctp.response.action.export.service;
+
+import com.jcraft.jsch.ChannelSftp;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.integration.sftp.session.DefaultSftpSessionFactory;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageBase;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageListener;
+import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
+import uk.gov.ons.ctp.response.action.export.config.AppConfig;
+import uk.gov.ons.ctp.response.action.export.message.SftpServicePublisher;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionAddress;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionContact;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionEvent;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionInstruction;
+import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
+import uk.gov.ons.ctp.response.action.message.instruction.Priority;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+
+import static junit.framework.TestCase.assertEquals;
+
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class TemplateServiceIT {
+
+    @Autowired
+    private AppConfig appConfig;
+
+    @Autowired
+    private DefaultSftpSessionFactory defaultSftpSessionFactory;
+
+    @Autowired
+    private SftpServicePublisher sftpService;
+
+    private SimpleMessageSender simpleMessageSender;
+    private SimpleMessageListener simpleMessageListener;
+
+    @Before
+    public void setUp() {
+        Rabbitmq rabbitConfig = this.appConfig.getRabbitmq();
+        simpleMessageSender = new SimpleMessageSender(
+                rabbitConfig.getHost(),
+                rabbitConfig.getPort(),
+                rabbitConfig.getUsername(),
+                rabbitConfig.getPassword());
+
+        simpleMessageListener = new SimpleMessageListener(
+                rabbitConfig.getHost(),
+                rabbitConfig.getPort(),
+                rabbitConfig.getUsername(),
+                rabbitConfig.getPassword());
+    }
+
+    @Test
+    public void testTemplateGeneratesCorrectPrintFileForSocial() throws JAXBException, InterruptedException, IOException {
+        // Given
+        ActionRequest actionRequest = createSocialNotificationActionRequest();
+
+        ActionInstruction actionInstruction = new ActionInstruction();
+        actionInstruction.setActionRequest(actionRequest);
+
+        JAXBContext jaxbContext = JAXBContext.newInstance(ActionInstruction.class);
+        StringWriter stringWriter = new StringWriter();
+        jaxbContext.createMarshaller().marshal(actionInstruction, stringWriter);
+
+        simpleMessageSender.sendMessage(
+                "action-outbound-exchange",
+                "Action.Printer.binding",
+                stringWriter.toString());
+
+        // When
+        BlockingQueue<String> queue = simpleMessageListener.listen(
+                SimpleMessageBase.ExchangeType.Fanout,
+                "event-message-outbound-exchange");
+
+        queue.take();
+
+        // Then
+        final String sftpPath = "Documents/sftp/";
+        ChannelSftp.LsEntry[] sftpList = defaultSftpSessionFactory.getSession().list(sftpPath);
+        Arrays.sort(sftpList, Comparator.comparingInt(o -> o.getAttrs().getMTime()));
+        String notificationFilePath = sftpPath + sftpList[sftpList.length - 1].getFilename();
+        InputStream inputSteam = defaultSftpSessionFactory.getSession().readRaw(notificationFilePath);
+
+        CSVRecord templateRow = readFirstCvRow(inputSteam);
+
+        assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.get(0));
+        assertEquals(actionRequest.getAddress().getLine1(), templateRow.get(1));
+        assertEquals("", templateRow.get(2));
+        assertEquals(actionRequest.getAddress().getPostcode(), templateRow.get(3));
+        assertEquals(actionRequest.getAddress().getTownName(), templateRow.get(4));
+        assertEquals(actionRequest.getIac(), templateRow.get(5));
+        assertEquals(actionRequest.getCaseRef(), templateRow.get(6));
+
+        defaultSftpSessionFactory.getSession().remove(notificationFilePath);
+
+    }
+
+    private CSVRecord readFirstCvRow(InputStream inputStream) throws IOException {
+        Reader reader = new InputStreamReader(inputStream);
+        CSVParser parser = new CSVParser(reader, CSVFormat.newFormat(':'));
+        try {
+            return parser.iterator().next();
+        } finally {
+            parser.close();
+            reader.close();
+        }
+    }
+
+    private ActionRequest createSocialNotificationActionRequest() {
+        ActionAddress actionAddress = new ActionAddress();
+        actionAddress.setSampleUnitRef("sampleUR");
+        actionAddress.setLine1("Prem1");
+        actionAddress.setPostcode("postCode");
+        actionAddress.setTownName("postTown");
+
+        ActionRequest actionRequest = new ActionRequest();
+        actionRequest.setActionId(UUID.randomUUID().toString());
+        actionRequest.setActionPlan("actionPlan");
+        actionRequest.setActionType("SOCIALNOT");
+        actionRequest.setAddress(actionAddress);
+        actionRequest.setQuestionSet("questions");
+        actionRequest.setLegalBasis("legalBasis");
+        actionRequest.setRegion("region");
+        actionRequest.setRespondentStatus("rStatus");
+        actionRequest.setEnrolmentStatus("eStatus");
+        actionRequest.setCaseGroupStatus("cgStatus");
+        actionRequest.setCaseId(UUID.randomUUID().toString());
+        actionRequest.setPriority(Priority.HIGHEST);
+        actionRequest.setCaseRef("caseRef");
+        actionRequest.setIac("test-iac");
+        actionRequest.setExerciseRef("exRef");
+        actionRequest.setContact(new ActionContact());
+        actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
+
+        return actionRequest;
+    }
+
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -18,7 +18,6 @@ import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageBase;
 import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageListener;
 import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
 import uk.gov.ons.ctp.response.action.export.config.AppConfig;
-import uk.gov.ons.ctp.response.action.export.message.SftpServicePublisher;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionAddress;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionContact;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionEvent;
@@ -77,7 +76,7 @@ public class TemplateServiceIT {
     }
 
     @Test
-    public void testTemplateGeneratesCorrectPrintFileForSocial() throws JAXBException, InterruptedException, IOException {
+    public void testTemplateGeneratesCorrectPrintFileForSocial() throws Exception {
         // Given
         ActionRequest actionRequest = createSocialNotificationActionRequest();
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -102,11 +102,11 @@ public class TemplateServiceIT {
 
         Iterator<String> templateRow = readFirstCsvRow(inputSteam).iterator();
 
-        assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.next());
         assertEquals(actionRequest.getAddress().getLine1(), templateRow.next());
         assertThat(templateRow.next(), isEmptyString());  // Address line 2 should be empty
         assertEquals(actionRequest.getAddress().getPostcode(), templateRow.next());
         assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
+        assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());
         assertEquals(actionRequest.getIac(), templateRow.next());
         assertEquals(actionRequest.getCaseRef(), templateRow.next());
 
@@ -144,6 +144,7 @@ public class TemplateServiceIT {
         actionAddress.setLine1("Prem1");
         actionAddress.setPostcode("postCode");
         actionAddress.setTownName("postTown");
+        actionAddress.setLocality("locality");
 
         ActionRequest actionRequest = new ActionRequest();
         actionRequest.setActionId(UUID.randomUUID().toString());

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -57,9 +57,6 @@ public class TemplateServiceIT {
     @Autowired
     private DefaultSftpSessionFactory defaultSftpSessionFactory;
 
-    @Autowired
-    private SftpServicePublisher sftpService;
-
     private SimpleMessageSender simpleMessageSender;
     private SimpleMessageListener simpleMessageListener;
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -107,7 +107,7 @@ public class TemplateServiceIT {
         String notificationFilePath = sftpPath + sftpList[sftpList.length - 1].getFilename();
         InputStream inputSteam = defaultSftpSessionFactory.getSession().readRaw(notificationFilePath);
 
-        CSVRecord templateRow = readFirstCvRow(inputSteam);
+        CSVRecord templateRow = readFirstCsvRow(inputSteam);
 
         assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.get(0));
         assertEquals(actionRequest.getAddress().getLine1(), templateRow.get(1));
@@ -121,7 +121,7 @@ public class TemplateServiceIT {
 
     }
 
-    private CSVRecord readFirstCvRow(InputStream inputStream) throws IOException {
+    private CSVRecord readFirstCsvRow(InputStream inputStream) throws IOException {
         Reader reader = new InputStreamReader(inputStream);
         CSVParser parser = new CSVParser(reader, CSVFormat.newFormat(':'));
         try {

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
@@ -139,7 +139,7 @@ public class TemplateServiceImplTest {
     Template template = cfg.getTemplate("initialPrint.ftl");
     Mockito.when(configuration.getTemplate("initialPrint")).thenReturn(template);
     ByteArrayOutputStream os = templateService.stream(testSocialActionRequest(), "initialPrint");
-    assertEquals("SampleUnitRef:testIac:InProgress:Pending:Created:Richard:Weeks:richard.weeks@ons.gov.uk:null\n", os.toString());
+    assertEquals("SampleUnitRef:testIac:InProgress:Pending:Created:Richard:Weeks:richard.weeks@ons.gov.uk:null:1000000000000001\n", os.toString());
   }
 
   private static List<ActionRequestInstruction> testSocialActionRequest() {

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
@@ -130,6 +130,37 @@ public class TemplateServiceImplTest {
     return Collections.singletonList(result);
   }
 
+
+  @Test
+  public void testTemplateGeneratesCorrectPrintFileForSocial() throws IOException, CTPException {
+    Configuration cfg = new Configuration(Configuration.VERSION_2_3_25);
+    cfg.setClassLoaderForTemplateLoading(Thread.currentThread().getContextClassLoader(), "templates/freemarker");
+    cfg.setDefaultEncoding("UTF-8");
+    Template template = cfg.getTemplate("initialPrint.ftl");
+    Mockito.when(configuration.getTemplate("initialPrint")).thenReturn(template);
+    ByteArrayOutputStream os = templateService.stream(testSocialActionRequest(), "initialPrint");
+    assertEquals("SampleUnitRef:testIac:InProgress:Pending:Created:Richard:Weeks:richard.weeks@ons.gov.uk:null\n", os.toString());
+  }
+
+  private static List<ActionRequestInstruction> testSocialActionRequest() {
+    ActionRequestInstruction result =  new ActionRequestInstruction();
+    Contact contact = new Contact();
+    Address address = new Address();
+    result.setActionId(UUID.randomUUID());
+    address.setSampleUnitRef("SampleUnitRef");
+    result.setIac("testIac");
+    result.setCaseGroupStatus("InProgress");
+    result.setEnrolmentStatus("Pending");
+    result.setRespondentStatus("Created");
+    contact.setForename("Richard");
+    contact.setSurname("Weeks");
+    contact.setEmailAddress("richard.weeks@ons.gov.uk");
+    result.setContact(contact);
+    result.setAddress(address);
+    result.setCaseRef("1000000000000001");
+    return Collections.singletonList(result);
+  }
+
   /**
    * Tests file issue retrieving template
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
@@ -3,7 +3,6 @@ package uk.gov.ons.ctp.response.action.export.service;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import junit.framework.TestCase;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceImplTest.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.ctp.response.action.export.service;
 
+import freemarker.template.Configuration;
 import freemarker.template.Template;
 import junit.framework.TestCase;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import freemarker.template.Configuration;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -21,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -130,36 +130,6 @@ public class TemplateServiceImplTest {
     return Collections.singletonList(result);
   }
 
-
-  @Test
-  public void testTemplateGeneratesCorrectPrintFileForSocial() throws IOException, CTPException {
-    Configuration cfg = new Configuration(Configuration.VERSION_2_3_25);
-    cfg.setClassLoaderForTemplateLoading(Thread.currentThread().getContextClassLoader(), "templates/freemarker");
-    cfg.setDefaultEncoding("UTF-8");
-    Template template = cfg.getTemplate("initialPrint.ftl");
-    Mockito.when(configuration.getTemplate("initialPrint")).thenReturn(template);
-    ByteArrayOutputStream os = templateService.stream(testSocialActionRequest(), "initialPrint");
-    assertEquals("SampleUnitRef:testIac:InProgress:Pending:Created:Richard:Weeks:richard.weeks@ons.gov.uk:null:1000000000000001\n", os.toString());
-  }
-
-  private static List<ActionRequestInstruction> testSocialActionRequest() {
-    ActionRequestInstruction result =  new ActionRequestInstruction();
-    Contact contact = new Contact();
-    Address address = new Address();
-    result.setActionId(UUID.randomUUID());
-    address.setSampleUnitRef("SampleUnitRef");
-    result.setIac("testIac");
-    result.setCaseGroupStatus("InProgress");
-    result.setEnrolmentStatus("Pending");
-    result.setRespondentStatus("Created");
-    contact.setForename("Richard");
-    contact.setSurname("Weeks");
-    contact.setEmailAddress("richard.weeks@ons.gov.uk");
-    result.setContact(contact);
-    result.setAddress(address);
-    result.setCaseRef("1000000000000001");
-    return Collections.singletonList(result);
-  }
 
   /**
    * Tests file issue retrieving template

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,7 +1,0 @@
-mongodb.server=localhost
-mongodb.database=actionExport
-sftp.host=localhost
-sftp.port=22
-sftp.username=centos
-sftp.password=JLibV2&XD,
-sftp.directory=Documents


### PR DESCRIPTION
# Motivation and Context
This changes adds the template for a social notification letter CSV template and the mapping for social action requests. This enables the action exporter service to generate the CSV files containing the addresses and other details required to generate the social notification letters. These CSV files are sent to an SFTP server to be picked up downstream.

# What has changed
* Added social notification file templates and template mapping rows to the SQL changes and updated changelogs accordingly.
* Added a docker-compose file to start up the services required for an integration test in docker locally. These run with names and ports specific to this service so should not conflict with the containers in [ras-rm-docker-dev](https://github.com/ONSdigital/ras-rm-docker-dev).
* Added an integration test which ensures that when an action instruction for a social notification is put on the relevant queue, this service picks it up, generates the correct CSV file and then sends it to the SFTP. 


# How to test?
Running a `mvn clean install` should now run the integration test for these changes, including running the required over services in docker and running this service locally.


# Links
Related to: https://github.com/ONSdigital/rm-action-service/pull/48
Trello card: [Dev task 5: INT: Notify respondent of invitation to a survey (5)](https://trello.com/c/xbFrDWWf/100-dev-task-5-int-notify-respondent-of-invitation-to-a-survey-5)
