### PR TITLE
Release perf 650

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.10-SNAPSHOT</version>
+  <version>10.49.10</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>
@@ -179,7 +179,7 @@
     <connection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</connection>
     <developerConnection>scm:git:https://github.com/ONSdigital/rm-actionexporter-service</developerConnection>
     <url>https://github.com/ONSdigital/rm-actionexporter-service</url>
-    <tag>actionexportersvc-10.49.8</tag>
+    <tag>actionexportersvc-10.49.10</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.10</version>
+  <version>10.49.10-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.10-SNAPSHOT</version>
+  <version>10.49.10</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>actionexportersvc</artifactId>
-  <version>10.49.10</version>
+  <version>10.49.11-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : ActionExporterService</name>


### PR DESCRIPTION
This branch was created to release the performance changes up to commit 09e0ffd9215284fbafe3b5d1759f2061ec9eb34b without including https://github.com/ONSdigital/rm-actionexporter-service/commit/954b9e5077779d0a6f2ce1bb22183788a34a55ac