### PR TITLE
Add social pre notification template and mapping

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -20,3 +20,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.50.0/changelog.yml
+
+  - include:
+      file: database/changes/release-10.50.1/changelog.yml

--- a/src/main/resources/database/changes/release-10.50.1/add_social_pre_notification_template.sql
+++ b/src/main/resources/database/changes/release-10.50.1/add_social_pre_notification_template.sql
@@ -1,0 +1,10 @@
+INSERT INTO actionexporter.template
+(templatenamepk, content, datemodified)
+VALUES('socialPreNotification', '<#list actionRequests as actionRequest>
+${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.caseRef)!"null"}
+</#list>', '2018-06-12 11:29:45.226');

--- a/src/main/resources/database/changes/release-10.50.1/add_social_pre_notification_template_mapping.sql
+++ b/src/main/resources/database/changes/release-10.50.1/add_social_pre_notification_template_mapping.sql
@@ -1,0 +1,4 @@
+INSERT INTO actionexporter.templatemapping
+(actiontypenamepk, templatenamefk, filenameprefix, datemodified)
+VALUES
+('SOCIALPRENOT','socialPreNotification', 'SOCIALPRENOT', now());

--- a/src/main/resources/database/changes/release-10.50.1/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.1/changelog.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.50.1-1
+      author: Adam Hawtin
+      changes:
+        - sqlFile:
+            comment: Added template for social pre notifications
+            path: add_social_pre_notification_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+
+  - changeSet:
+      id: 10.50.1-2
+      author: Adam Hawtin
+      changes:
+        - sqlFile:
+            comment: Added template mapping for social pre notifications
+            path: add_social_pre_notification_template_mapping.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -142,7 +142,7 @@ public class TemplateServiceIT {
         Iterator<String> templateRow = readFirstCsvRow(inputSteam).iterator();
 
         String notificationFile = StringUtils.substringAfterLast(notificationFilePath, "/");
-        assertEquals("SOCIALPRENOT", StringUtils.substringBefore(notificationFile,"_"));
+        assertEquals("SOCIALPRENOT", StringUtils.substringBefore(notificationFile, "_"));
 
         assertEquals(actionRequest.getAddress().getLine1(), templateRow.next());
         assertThat(templateRow.next(), isEmptyString());  // Address line 2 should be empty
@@ -179,7 +179,7 @@ public class TemplateServiceIT {
         }
     }
 
-    private ActionRequest createSocialActionRequest(String actionType) {
+    private ActionRequest createSocialActionRequest(final String actionType) {
         ActionAddress actionAddress = new ActionAddress();
         actionAddress.setSampleUnitRef("sampleUR");
         actionAddress.setLine1("Prem1");


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Social surveys have a "Pre Notification" letter that is sent out purely to notify potential respondents before the actual notification which contains their UAC to access the survey online. This PR adds the template for the CSV file containing the address information used to generate these pre notification letters and the template mapping necessary to use this template for `SOCIALPRENOT` action types.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add template for social pre notification letter `.csv` files
* Add template mapping for `SOCIALPRENOT` action types
* Add integration test for generation of social pre notification `.csv` file

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
The new integration test should pass, and after starting the service on this branch you should be able to see the new template and mapping in the database in the `actionexporter` schema in the `template` and `templatemapping` tables.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
Related changes in action service: https://github.com/ONSdigital/rm-action-service/pull/54
Trello card: [Dev task 3A: INT: Create csv file for pre-notification template (8)](https://trello.com/c/6mwgWN5K/145-dev-task-3a-int-create-csv-file-for-pre-notification-template-8)