### PR TITLE
A simple PR to change (pre)notifications to include sampleUnitRef instead of caseRef

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.product</groupId>
       <artifactId>actionsvc-api</artifactId>
-      <version>10.49.7</version>
+      <version>10.49.20</version>
     </dependency>
 
     <dependency>

--- a/src/main/resources/database/changes/release-10.50.1/changelog.yml
+++ b/src/main/resources/database/changes/release-10.50.1/changelog.yml
@@ -19,3 +19,13 @@ databaseChangeLog:
             path: add_social_pre_notification_template_mapping.sql
             relativeToChangelogFile: true
             splitStatements: false
+
+  - changeSet:
+      id: 10.50.1-3
+      author: Matt Innes
+      changes:
+        - sqlFile:
+            comment: Updated social template to use sampleUnitRef instead of caseRef
+            path: use_sample_unit_ref.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-10.50.1/use_sample_unit_ref.sql
+++ b/src/main/resources/database/changes/release-10.50.1/use_sample_unit_ref.sql
@@ -1,0 +1,26 @@
+UPDATE actionexporter.template
+SET content = '<#list actionRequests as actionRequest>' ||
+'${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.iac?trim)!"null"}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}
+</#list>',
+  datemodified = now()
+WHERE templatenamepk = 'socialNotification';
+
+UPDATE actionexporter.template
+  SET content = '<#list actionRequests as actionRequest>' ||
+'${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}
+</#list>',
+  datemodified = now()
+WHERE templatenamepk = 'socialPreNotification';
+
+

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -106,7 +106,7 @@ public class TemplateServiceIT {
     assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
     assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());
     assertEquals(actionRequest.getIac(), templateRow.next());
-    assertEquals(actionRequest.getCaseRef(), templateRow.next());
+    assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.next());
 
     // Delete the file created in this test
     defaultSftpSessionFactory.getSession().remove(notificationFilePath);
@@ -146,7 +146,7 @@ public class TemplateServiceIT {
     assertEquals(actionRequest.getAddress().getPostcode(), templateRow.next());
     assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
     assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());
-    assertEquals(actionRequest.getCaseRef(), templateRow.next());
+    assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.next());
 
     // Delete the file created in this test
     defaultSftpSessionFactory.getSession().remove(notificationFilePath);


### PR DESCRIPTION
# Motivation and Context
Currently the notifications and pre-notifications for social include caseRef (which looks something like 1000000100010).  This PR changes this to something more business friendly i.e. sampleUnitRef (which looks something like LMS00001).  

# What has changed
- a liquibase script has been added to change the freemarker for the social notifications and pre-notifications
- integration tests have been changed to confirm that result includes sample unit ref not case ref
- updated rm-actionsvc-api dependency version to latest (please note: this will cause travis builds to fail until change is merged)

# How to test?
- check out branch
- run integration tests
- for a more detailed examination run either of the integration tests testTemplateGeneratesCorrectPrintFileForSocial or testTemplateGeneratesCorrectPrintFileForSocialPreNotification in the debugger and examine the data to ensure the sampleUnitRef is included
