### PR TITLE
Added address lines 3 and 4 to Address table and notification file

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/domain/Address.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/domain/Address.java
@@ -41,6 +41,12 @@ public class Address {
   @Column(name = "address_line2")
   private String line2;
 
+  @Column(name = "address_line3")
+  private String line3;
+
+  @Column(name = "address_line4")
+  private String line4;
+
   private String locality;
 
   private String townName;

--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -23,3 +23,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.50.1/changelog.yml
+
+  - include:
+      file: database/changes/release-10.51.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_address.sql
+++ b/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_address.sql
@@ -1,0 +1,5 @@
+ALTER TABLE actionexporter.address ADD COLUMN address_line3 varchar(60);
+ALTER TABLE actionexporter.address ADD COLUMN address_line4 varchar(60);
+
+-- Please note that Postgres has no support for reordering the positions of columns.
+-- Thus, these two columns will appear at the end of the address table.

--- a/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_notif_template.sql
+++ b/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_notif_template.sql
@@ -9,7 +9,6 @@ SET content =
 '${(actionRequest.address.townName?trim)!}:' ||
 '${(actionRequest.address.locality?trim)!}:' ||
 '${(actionRequest.iac?trim)!"null"}:' ||
-'${(actionRequest.caseRef)!"null"}:' ||
 '${(actionRequest.address.sampleUnitRef)!"null"}' ||
 '</#list>', datemodified = now()
 where templatenamepk = 'socialNotification'

--- a/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_notif_template.sql
+++ b/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_notif_template.sql
@@ -1,0 +1,15 @@
+UPDATE actionexporter.template
+SET content =
+'<#list actionRequests as actionRequest>' ||
+'${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.line3?trim)!}:' ||
+'${(actionRequest.address.line4?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.iac?trim)!"null"}:' ||
+'${(actionRequest.caseRef)!"null"}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}' ||
+'</#list>', datemodified = now()
+where templatenamepk = 'socialNotification'

--- a/src/main/resources/database/changes/release-10.51.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.51.0/changelog.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.51.0-1
+      author: Damien Lloyd
+      changes:
+        - sqlFile:
+            comment: Add lines 3 and 4 to address table
+            path: add_lines_3_4_address.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+
+
+  - changeSet:
+      id: 10.51.0-2
+      author: Damien Lloyd
+      changes:
+        - sqlFile:
+            comment: Add address lines 3 and 4 to social notification template
+            path: add_lines_3_4_social_notif_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -108,7 +108,6 @@ public class TemplateServiceIT {
     assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
     assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());
     assertEquals(actionRequest.getIac(), templateRow.next());
-    assertEquals(actionRequest.getCaseRef(), templateRow.next());
     assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.next());
 
     // Delete the file created in this test

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -102,10 +102,13 @@ public class TemplateServiceIT {
 
     assertEquals(actionRequest.getAddress().getLine1(), templateRow.next());
     assertThat(templateRow.next(), isEmptyString()); // Address line 2 should be empty
+    assertEquals(actionRequest.getAddress().getLine3(), templateRow.next());
+    assertEquals(actionRequest.getAddress().getLine4(), templateRow.next());
     assertEquals(actionRequest.getAddress().getPostcode(), templateRow.next());
     assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
     assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());
     assertEquals(actionRequest.getIac(), templateRow.next());
+    assertEquals(actionRequest.getCaseRef(), templateRow.next());
     assertEquals(actionRequest.getAddress().getSampleUnitRef(), templateRow.next());
 
     // Delete the file created in this test
@@ -178,6 +181,8 @@ public class TemplateServiceIT {
     ActionAddress actionAddress = new ActionAddress();
     actionAddress.setSampleUnitRef("sampleUR");
     actionAddress.setLine1("Prem1");
+    actionAddress.setLine3("Prem3");
+    actionAddress.setLine4("Prem4");
     actionAddress.setPostcode("postCode");
     actionAddress.setTownName("postTown");
     actionAddress.setLocality("locality");


### PR DESCRIPTION
# Motivation and Context
Lines 3 and 4 were added to the address table and notification file as households typically have lines 3 and 4 in the address.

# What has changed
Two deltas: one adds lines 3 and 4 to the table itself; the other adds lines 3 and 4 to the template which will generate a CSV file on a schedule.

# How to test?
Run all tests in TemplateServiceIT
