### PR TITLE
Addlines 3 and 4 to pre-notification template

### DIFF
--- a/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_pre_notif_template.sql
+++ b/src/main/resources/database/changes/release-10.51.0/add_lines_3_4_social_pre_notif_template.sql
@@ -1,0 +1,13 @@
+UPDATE actionexporter.template
+SET content =
+'<#list actionRequests as actionRequest>' ||
+'${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.line3?trim)!}:' ||
+'${(actionRequest.address.line4?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}' ||
+'</#list>', datemodified = now()
+where templatenamepk = 'socialPreNotification'

--- a/src/main/resources/database/changes/release-10.51.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.51.0/changelog.yml
@@ -20,3 +20,13 @@ databaseChangeLog:
             path: add_lines_3_4_social_notif_template.sql
             relativeToChangelogFile: true
             splitStatements: false
+
+  - changeSet:
+      id: 10.51.0-3
+      author: Damien Lloyd
+      changes:
+        - sqlFile:
+            comment: Add address lines 3 and 4 to social pre-notification template
+            path: add_lines_3_4_social_pre_notif_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -145,6 +145,8 @@ public class TemplateServiceIT {
 
     assertEquals(actionRequest.getAddress().getLine1(), templateRow.next());
     assertThat(templateRow.next(), isEmptyString()); // Address line 2 should be empty
+    assertEquals(actionRequest.getAddress().getLine3(), templateRow.next());
+    assertEquals(actionRequest.getAddress().getLine4(), templateRow.next());
     assertEquals(actionRequest.getAddress().getPostcode(), templateRow.next());
     assertEquals(actionRequest.getAddress().getTownName(), templateRow.next());
     assertEquals(actionRequest.getAddress().getLocality(), templateRow.next());


### PR DESCRIPTION
# Motivation and Context
Pre notification templates require lines 3 and 4 so that when households first receive an invite to complete the survey it is handed over to the candidate respondent whose address would contain lines 3 and 4 of a valid UK address.

# What has changed
Delta created to add lines 3 and 4 to pre-notification template

# How to test?
Run all tests in TemplateServiceIT
