### PR TITLE
Add BSNL and BSRL template mappings

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -10,7 +10,7 @@ databaseChangeLog:
       file: database/changes/release-10.44.0/changelog.yml
 
   - include:
-      file: database/changes/release-10.45.0/changelog.yml      
+      file: database/changes/release-10.45.0/changelog.yml
 
   - include:
       file: database/changes/release-10.47.0/changelog.yml
@@ -29,3 +29,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.52.0/changelog.yml
+
+  - include:
+      file: database/changes/release-11/changelog.yml

--- a/src/main/resources/database/changes/release-11/add_BSNL_and_BSRL.sql
+++ b/src/main/resources/database/changes/release-11/add_BSNL_and_BSRL.sql
@@ -1,0 +1,9 @@
+INSERT INTO actionexporter.templatemapping(
+actiontypenamepk, templatenamefk, filenameprefix, datemodified)
+VALUES ('BSNL', 'initialPrint', 'BSNOT',now())
+ON CONFLICT (actiontypenamepk) DO NOTHING;
+
+INSERT INTO actionexporter.templatemapping(
+actiontypenamepk, templatenamefk, filenameprefix, datemodified)
+VALUES ('BSRL', 'initialPrint', 'BSREM', now())
+ON CONFLICT (actiontypenamepk) DO NOTHING;

--- a/src/main/resources/database/changes/release-11/changelog.yml
+++ b/src/main/resources/database/changes/release-11/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 11
+      author: Tom Oram
+      changes:
+        - sqlFile:
+            comment: Add BNSL and BSRL template mappings
+            path: add_BSNL_and_BSRL.sql
+            relativeToChangelogFile: true
+            splitStatements: false


### PR DESCRIPTION
# Motivation and Context
For new environments these currently have to be added manually. In production there are already there so I've added `ON CONFLICT (..) DO NOTHING` to the insert statements.

# What has changed
- New migration file which adds the template mappings
- Moved to a new `release-<single int>` format for the migrations as discussed with @pricem14pc and @madeye-matt 

# How to test?
1. Ensure that `BSNL` and `BSRL` is not present in the `templatemapping` table
1. Start up the service
1. Ensure that the `BSNL` and `BSRL` rows have been added
