### PR TITLE
Add new line to templates

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -26,3 +26,6 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-10.51.0/changelog.yml
+
+  - include:
+      file: database/changes/release-10.52.0/changelog.yml

--- a/src/main/resources/database/changes/release-10.52.0/add_lines_3_4_social_notif_template.sql
+++ b/src/main/resources/database/changes/release-10.52.0/add_lines_3_4_social_notif_template.sql
@@ -1,0 +1,14 @@
+UPDATE actionexporter.template
+SET content =
+'<#list actionRequests as actionRequest>
+${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.line3?trim)!}:' ||
+'${(actionRequest.address.line4?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.iac?trim)!"null"}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}
+</#list>', datemodified = now()
+where templatenamepk = 'socialNotification'

--- a/src/main/resources/database/changes/release-10.52.0/add_lines_3_4_social_pre_notif_template.sql
+++ b/src/main/resources/database/changes/release-10.52.0/add_lines_3_4_social_pre_notif_template.sql
@@ -1,0 +1,13 @@
+UPDATE actionexporter.template
+SET content =
+'<#list actionRequests as actionRequest>
+${(actionRequest.address.line1?trim)!}:' ||
+'${(actionRequest.address.line2?trim)!}:' ||
+'${(actionRequest.address.line3?trim)!}:' ||
+'${(actionRequest.address.line4?trim)!}:' ||
+'${(actionRequest.address.postcode?trim)!}:' ||
+'${(actionRequest.address.townName?trim)!}:' ||
+'${(actionRequest.address.locality?trim)!}:' ||
+'${(actionRequest.address.sampleUnitRef)!"null"}
+</#list>', datemodified = now()
+where templatenamepk = 'socialPreNotification'

--- a/src/main/resources/database/changes/release-10.52.0/changelog.yml
+++ b/src/main/resources/database/changes/release-10.52.0/changelog.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 10.52.0-1
+      author: Ben Jefferies
+      changes:
+        - sqlFile:
+            comment: Add address lines 3 and 4 to social notification template
+            path: add_lines_3_4_social_notif_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false
+
+  - changeSet:
+      id: 10.52.0-2
+      author: Ben Jefferies
+      changes:
+        - sqlFile:
+            comment: Add address lines 3 and 4 to social pre-notification template
+            path: add_lines_3_4_social_pre_notif_template.sql
+            relativeToChangelogFile: true
+            splitStatements: false


### PR DESCRIPTION
# Motivation and Context
The templates need a new line at the end to stop lines all being
on one line. IT tests have been added to check this but ideally we'd
refactor these into unit tests when the templates no longer live in the DB

# What has changed
* Scripts to update the social print file templates with new line characters
* Check the row ends with a newline character in the integration test

# How to test?
Run integration tests

# Links
https://trello.com/c/2oPPgbXs/184-add-prem3-and-prem4-to-the-notification-file-5
https://trello.com/c/AAGDVYKL/183-add-prem3-and-prem4-to-pre-notification-template-3
