### PR TITLE
Removed native queries

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/repository/ActionRequestRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/repository/ActionRequestRepository.java
@@ -91,10 +91,5 @@ public interface ActionRequestRepository extends BaseRepository<ActionRequestIns
    * @param actionId to check for existence
    * @return boolean whether exists
    */
-  @Query(
-      value =
-          "select exists(select 1 from actionexporter.actionrequest where "
-              + "actionid=:p_actionid)",
-      nativeQuery = true)
-  boolean tupleExists(@Param("p_actionid") UUID actionId);
+  boolean existsByActionId(UUID actionId);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/repository/AddressRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/repository/AddressRepository.java
@@ -1,8 +1,6 @@
 package uk.gov.ons.ctp.response.action.export.repository;
 
 import java.util.UUID;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.ons.ctp.response.action.export.domain.Address;
 
@@ -13,11 +11,8 @@ public interface AddressRepository extends BaseRepository<Address, UUID> {
   /**
    * Check repository for sampleunitrefpk existence
    *
-   * @param sampleUnitRefpk to check for existence
+   * @param sampleUnitRef to check for existence
    * @return boolean whether exists
    */
-  @Query(
-      value = "select exists(select 1 from actionexporter.address where sampleunitrefpk=:p_surpk)",
-      nativeQuery = true)
-  boolean tupleExists(@Param("p_surpk") String sampleUnitRefpk);
+  boolean existsBySampleUnitRef(String sampleUnitRef);
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/impl/ActionExportServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/impl/ActionExportServiceImpl.java
@@ -73,12 +73,12 @@ public class ActionExportServiceImpl implements ActionExportService {
     Timestamp now = DateTimeUtil.nowUTC();
     actionRequestDoc.setDateStored(now);
 
-    if (!addressRepo.tupleExists(actionRequestDoc.getAddress().getSampleUnitRef())) {
+    if (!addressRepo.existsBySampleUnitRef(actionRequestDoc.getAddress().getSampleUnitRef())) {
       // Address should never change so do not save if already exists
       addressRepo.persist(actionRequestDoc.getAddress());
     }
 
-    if (actionRequestRepo.tupleExists(actionRequestDoc.getActionId())) {
+    if (actionRequestRepo.existsByActionId(actionRequestDoc.getActionId())) {
       // ActionRequests should never be sent twice with same actionId but...
       log.warn("Key ActionId {} already exists", actionRequestDoc.getActionId());
     } else {


### PR DESCRIPTION
# Motivation and Context
Improvements team is refactoring all the native Postgres queries which are hard-coded into the repositories, so that JPA is used instead. This should allow us to use Hibernate caching and give us greater stability, because we're not bypassing the persistence framework.

# What has changed
Replaced 2 repository methods with JPA equivalent.

# How to test?
Ran acceptance tests - passing

# Links
Trello: https://trello.com/c/bdqQthEj/291-replace-native-postgres-queries-with-jpa-spring-data-queries-in-java-services-l