### PR TITLE
Roll out Godaddy logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>uk.gov.ons.ctp.product</groupId>
         <artifactId>rm-common-config</artifactId>
-        <version>10.49.11</version>
+        <version>10.49.13</version>
     </parent>
 
     <scm>
@@ -191,6 +191,10 @@
             <artifactId>cobertura</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.godaddy</groupId>
+            <artifactId>logging</artifactId>
+        </dependency>
         <!-- Third party end -->
 
         <!-- Testing -->

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.response.action;
 
+import com.godaddy.logging.LoggingConfigs;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
@@ -126,6 +127,8 @@ public class ActionExporterApplication {
    * @param args These are the optional command line arguments
    */
   public static void main(final String[] args) {
+    LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
+
     SpringApplication.run(ActionExporterApplication.class, args);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/domain/ExportMessage.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/domain/ExportMessage.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.action.export.domain;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -11,7 +13,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.cobertura.CoverageIgnore;
 
 /** Representation of a message being sent. */
@@ -19,8 +20,8 @@ import net.sourceforge.cobertura.CoverageIgnore;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
-@Slf4j
 public class ExportMessage {
+  private static final Logger log = LoggerFactory.getLogger(ExportMessage.class);
 
   private Map<String, List<UUID>> actionRequestIds = new HashMap<String, List<UUID>>();
   private Map<String, ByteArrayOutputStream> outputStreams =

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/endpoint/TemplateEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/endpoint/TemplateEndpoint.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.ctp.response.action.export.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,8 +25,9 @@ import uk.gov.ons.ctp.response.action.export.service.TemplateService;
 /** The REST endpoint controller for Templates. */
 @RestController
 @RequestMapping(value = "/templates", produces = "application/json")
-@Slf4j
 public class TemplateEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(TemplateEndpoint.class);
+
   @Autowired private TemplateService templateService;
 
   @Qualifier("actionExporterBeanMapper")

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/endpoint/TemplateMappingEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/endpoint/TemplateMappingEndpoint.java
@@ -1,8 +1,9 @@
 package uk.gov.ons.ctp.response.action.export.endpoint;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.net.URI;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,8 +23,9 @@ import uk.gov.ons.ctp.response.action.export.service.TemplateMappingService;
 /** The REST endpoint controller for TemplateMappings. */
 @RestController
 @RequestMapping(value = "/templatemappings", produces = "application/json")
-@Slf4j
 public class TemplateMappingEndpoint {
+  private static final Logger log = LoggerFactory.getLogger(TemplateMappingEndpoint.class);
+
   @Autowired private TemplateMappingService templateMappingService;
 
   @Qualifier("actionExporterBeanMapper")

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/ActionFeedbackPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/ActionFeedbackPublisher.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.response.action.export.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,8 +13,8 @@ import uk.gov.ons.ctp.response.action.message.feedback.ActionFeedback;
  * service.
  */
 @MessageEndpoint
-@Slf4j
 public class ActionFeedbackPublisher {
+  private static final Logger log = LoggerFactory.getLogger(ActionFeedbackPublisher.class);
 
   @Qualifier("actionFeedbackRabbitTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/EventPublisher.java
@@ -1,14 +1,15 @@
 package uk.gov.ons.ctp.response.action.export.message;
 
-import lombok.extern.slf4j.Slf4j;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.integration.annotation.MessageEndpoint;
 
 @MessageEndpoint
-@Slf4j
 public class EventPublisher {
+  private static final Logger log = LoggerFactory.getLogger(EventPublisher.class);
 
   @Qualifier("amqpTemplate")
   @Autowired

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.response.action.export.message;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
 import java.sql.Timestamp;
@@ -8,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Publisher;
@@ -32,8 +33,8 @@ import uk.gov.ons.ctp.response.action.message.feedback.Outcome;
  * Integration flow for details of sftp outbound channel.
  */
 @MessageEndpoint
-@Slf4j
 public class SftpServicePublisher {
+  private static final Logger log = LoggerFactory.getLogger(SftpServicePublisher.class);
 
   private static final String DATE_FORMAT = "dd/MM/yyyy HH:mm";
   private static final String ACTION_LIST = "list_actionIds";

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.export.scheduled;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
@@ -28,8 +29,8 @@ import uk.gov.ons.ctp.response.action.export.service.TransformationService;
 
 /** This class will be responsible for the scheduling of export actions */
 @Component
-@Slf4j
 public class ExportScheduler implements HealthIndicator {
+  private static final Logger log = LoggerFactory.getLogger(ExportScheduler.class);
 
   private static final String DATE_FORMAT_IN_FILE_NAMES = "ddMMyyyy_HHmm";
   private static final String DISTRIBUTED_OBJECT_KEY_FILE_LATCH = "filelatch";

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionExportService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionExportService.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.export.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -24,8 +25,8 @@ import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 
 /** Service implementation responsible for persisting action export requests */
 @Service
-@Slf4j
 public class ActionExportService {
+  private static final Logger log = LoggerFactory.getLogger(ActionExportService.class);
 
   private static final String DATE_FORMAT = "dd/MM/yyyy HH:mm";
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionRequestService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/ActionRequestService.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.ctp.response.action.export.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.response.action.export.domain.ActionRequestInstruction;
@@ -13,8 +14,8 @@ import uk.gov.ons.ctp.response.action.export.repository.ActionRequestRepository;
 
 /** The implementation of ActionRequestService */
 @Service
-@Slf4j
 public class ActionRequestService {
+  private static final Logger log = LoggerFactory.getLogger(ActionRequestService.class);
 
   @Autowired private ActionRequestRepository repository;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateMappingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateMappingService.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.export.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -14,8 +15,8 @@ import uk.gov.ons.ctp.response.action.export.repository.TemplateMappingRepositor
 
 /** The implementation of the TemplateMappingService */
 @Service
-@Slf4j
 public class TemplateMappingService {
+  private static final Logger log = LoggerFactory.getLogger(TemplateMappingService.class);
 
   public static final String EXCEPTION_STORE_TEMPLATE_MAPPING =
       "Issue storing TemplateMapping. Appears to be empty.";

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateService.java
@@ -2,6 +2,8 @@ package uk.gov.ons.ctp.response.action.export.service;
 
 import static uk.gov.ons.ctp.common.util.InputStreamUtils.getStringFromInputStream;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import java.io.ByteArrayOutputStream;
@@ -15,7 +17,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -29,8 +30,8 @@ import uk.gov.ons.ctp.response.action.export.repository.TemplateRepository;
  * freemarker.template.Configuration, clearTemplateCache, etc.
  */
 @Service
-@Slf4j
 public class TemplateService {
+  private static final Logger log = LoggerFactory.getLogger(TemplateService.class);
 
   public static final String ERROR_RETRIEVING_FREEMARKER_TEMPLATE =
       "Could not find FreeMarker template.";

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/TransformationService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/TransformationService.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.ctp.response.action.export.service;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.error.CTPException;
@@ -15,8 +16,8 @@ import uk.gov.ons.ctp.response.action.export.domain.TemplateMapping;
 
 /** The implementation of TransformationService */
 @Service
-@Slf4j
 public class TransformationService {
+  private static final Logger log = LoggerFactory.getLogger(TransformationService.class);
 
   @Autowired private TemplateService templateService;
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/templating/freemarker/config/FreeMarkerTemplateLoader.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/templating/freemarker/config/FreeMarkerTemplateLoader.java
@@ -1,19 +1,20 @@
 package uk.gov.ons.ctp.response.action.export.templating.freemarker.config;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import freemarker.cache.TemplateLoader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.response.action.export.domain.TemplateExpression;
 import uk.gov.ons.ctp.response.action.export.repository.TemplateRepository;
 
 /** TemplateLoader to load templates stored in MongopDB */
-@Slf4j
 @Component
 public class FreeMarkerTemplateLoader implements TemplateLoader {
+  private static final Logger log = LoggerFactory.getLogger(FreeMarkerTemplateLoader.class);
 
   @Autowired private TemplateRepository templateRepository;
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,30 +9,49 @@
     value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p})  %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
   <property name="SYSLOG_PATTERN"
     value="${LOG_LEVEL_PATTERN:-%5level} %-40.40logger{39} : %message%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
+  <property name="ISO8601_DATE_FORMAT" value="yyyy-MM-dd'T'HH:mm:ss'Z'" />
 
   <appender name="CLOUD" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
       <providers>
-        <mdc/>
-        <pattern>
-          <pattern>
-            {
-            "created": "%date{ISO8601}",
-            "service": "actionexportersvc",
-            "level": "%level",
-            "event": "%message"
-            }
-          </pattern>
-        </pattern>
-      <stackTrace>
-        <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-          <maxDepthPerThrowable>30</maxDepthPerThrowable>
-          <shortenedClassNameLength>20</shortenedClassNameLength>
-          <exclude>^sun\.reflect\..*\.invoke</exclude>
-          <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
-          <rootCauseFirst>true</rootCauseFirst>
-        </throwableConverter>
-      </stackTrace>
+        <timestamp>
+          <timeZone>UTC</timeZone>
+          <pattern>${ISO8601_DATE_FORMAT}</pattern>
+          <fieldName>created</fieldName>
+        </timestamp>
+        <globalCustomFields>
+          <customFields>{"service":"actionexportersvc"}</customFields>
+        </globalCustomFields>
+        <message>
+          <fieldName>event</fieldName>
+        </message>
+        <loggerName/>
+        <threadName/>
+        <logLevel>
+          <fieldName>level</fieldName>
+        </logLevel>
+        <stackTrace>
+          <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+            <maxDepthPerThrowable>20</maxDepthPerThrowable>
+            <maxLength>1000</maxLength>
+            <shortenedClassNameLength>30</shortenedClassNameLength>
+            <rootCauseFirst>true</rootCauseFirst>
+            <exclude>^sun\.reflect\..*\.invoke</exclude>
+            <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+          </throwableConverter>
+        </stackTrace>
+        <context/>
+        <jsonMessage/>
+        <mdc>
+          <includeMdcKeyName>included</includeMdcKeyName>
+        </mdc>
+        <contextMap/>
+        <tags/>
+        <logstashMarkers/>
+        <arguments>
+          <includeNonStructuredArguments>true</includeNonStructuredArguments>
+          <nonStructuredArgumentsFieldPrefix>prefix</nonStructuredArgumentsFieldPrefix>
+        </arguments>
       </providers>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -5,6 +5,8 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.junit.Assert.assertThat;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import com.jcraft.jsch.ChannelSftp;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +21,6 @@ import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.lang3.StringUtils;
@@ -48,8 +49,8 @@ import uk.gov.ons.ctp.response.action.message.instruction.Priority;
 @ContextConfiguration
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@Slf4j
 public class TemplateServiceIT {
+  private static final Logger log = LoggerFactory.getLogger(TemplateServiceIT.class);
 
   @Autowired private AppConfig appConfig;
 


### PR DESCRIPTION
# Motivation and Context
We've agreed to use the Godaddy logger for structured JSON logging, which we are now rolling out to all the Java services.

# What has changed
Replaced all the `@Slf4j` annotations. Updated the logback.xml config.

# How to test?
Run with CLOUD profile and check that the logs are coming out in the correct JSON format.

# Links
Trello: https://trello.com/c/2cLIClJa/348-roll-out-godaddy-logger-to-all-the-other-java-services

Architecture decision: https://github.com/ONSdigital/sdc/blob/master/doc/architecture/decisions/godaddy-structured-json-logging-java.md