### PR TITLE
Revert "Merge branch 'master' into handle_retries_correctly"

### DIFF
--- a/src/main/resources/springintegration/action-instruction-inbound-flow.xml
+++ b/src/main/resources/springintegration/action-instruction-inbound-flow.xml
@@ -55,8 +55,7 @@
         </property>
         <property name="retryStateGenerator"> <!-- Important to make it a Stateful Retry -->
             <bean class="org.springframework.integration.handler.advice.SpelExpressionRetryStateGenerator">
-                <constructor-arg value="payload.actionRequest.actionId + '|' + payload.actionRequest.contact.emailAddress"/>
-                <!-- Ensure spel expression is unique otherwise messages pertaining to this key will not be retried after {maxInterval} times -->
+                <constructor-arg value="headers.ID"/>
             </bean>
         </property>
         <property name="retryTemplate" ref="retryTemplate" />


### PR DESCRIPTION
# Motivation and Context
This reverts commit 9ec882c6071bb0e199f1505f173be8e1daa98945, reversing
changes made to 91caaaf8483468eb39e4fc1e4cfd081e22ed0222.

payload.actionRequest.contact.emailAddress is not always populated and
can result in infinitely retrying because of a null pointer exception is
thrown with the log being

```
SpelEvaluationException: EL1007E: Property or field 'emailAddress' cannot be found on null
```

# What has changed
Reverting retry strategy

# How to test?
Check logs aren't raising exception when running the acceptance tests
```
   2018-08-23T14:42:52.60+0100 [APP/PROC/WEB/0] OUT Caused by: org.springframework.messaging.MessageHandlingException: error occurred in message handler [ServiceActivator for [org.springframework.integration.handler.MethodInvokingMessageProcessor@6aed7784] (actionExportReceiver.acceptInstruction.serviceActivator.handler)]; nested exception is org.springframework.expression.spel.SpelEvaluationException: EL1007E: Property or field 'emailAddress' cannot be found on null
```


# Links
