### PR TITLE
Init JSON logging in PostConstruct method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,9 +164,14 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-            <version>10.49.12</version>
+            <version>10.49.17</version>
         </dependency>
 
+        <dependency>
+            <groupId>uk.gov.ons.tools</groupId>
+            <artifactId>rabbit</artifactId>
+            <version>1.0.0</version>
+        </dependency>
         <!-- ONS END -->
 
         <!-- Third party libraries -->

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
@@ -128,7 +128,6 @@ public class ActionExporterApplication {
    * @param args These are the optional command line arguments
    */
   public static void main(final String[] args) {
-
     SpringApplication.run(ActionExporterApplication.class, args);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
@@ -1,12 +1,12 @@
 package uk.gov.ons.ctp.response.action;
 
 import com.godaddy.logging.LoggingConfigs;
+import javax.annotation.PostConstruct;
 import net.sourceforge.cobertura.CoverageIgnore;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -45,7 +45,7 @@ import uk.gov.ons.ctp.response.action.export.repository.impl.BaseRepositoryImpl;
 @EnableCaching
 @EnableScheduling
 @ImportResource("springintegration/main.xml")
-public class ActionExporterApplication implements CommandLineRunner {
+public class ActionExporterApplication {
 
   public static final String ACTION_EXECUTION_LOCK = "actionexport.request.execution";
 
@@ -132,8 +132,8 @@ public class ActionExporterApplication implements CommandLineRunner {
     SpringApplication.run(ActionExporterApplication.class, args);
   }
 
-  @Override
-  public void run(String... args) throws Exception {
+  @PostConstruct
+  public void initJsonLogging() {
     if (appConfig.getLogging().isUseJson()) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/TemplateServiceIT.java
@@ -36,9 +36,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
-import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageBase;
-import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageListener;
-import uk.gov.ons.ctp.common.message.rabbit.SimpleMessageSender;
 import uk.gov.ons.ctp.response.action.export.config.AppConfig;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionAddress;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionContact;
@@ -46,6 +43,9 @@ import uk.gov.ons.ctp.response.action.message.instruction.ActionEvent;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionInstruction;
 import uk.gov.ons.ctp.response.action.message.instruction.ActionRequest;
 import uk.gov.ons.ctp.response.action.message.instruction.Priority;
+import uk.gov.ons.tools.rabbit.SimpleMessageBase;
+import uk.gov.ons.tools.rabbit.SimpleMessageListener;
+import uk.gov.ons.tools.rabbit.SimpleMessageSender;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration


### PR DESCRIPTION
# Motivation and Context
Bug discovered by @ajmaddaford in CI-latest where JSON not being used for key-value pairs.

# What has changed
Instead of flipping logging to use JSON in a `CommandLineRunner.run()` method, we're using a `@Postconstruct` instead, which should always fire.

# How to test?
Run with `--spring.profiles.active=cloud` or hack the `application.yml` to set `CLOUD` logger and `useJson=true`

# Links
Related Trello card: https://trello.com/c/KNOUa0pq/349-update-logging-in-all-java-services-to-use-key-value-pairs