### PR TITLE
Remove log line filling up logs with useless info

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
@@ -76,7 +76,6 @@ public class NotificationFileCreator {
     final String now = FILENAME_DATE_FORMAT.format(clock.millis());
     String filename = String.format("%s_%s.csv", filenamePrefix, now);
     if (exportData.isEmpty()) {
-      log.with("filename", filename).info("No data to generate file");
       return;
     }
     log.with("filename", filename).info("Uploading file");


### PR DESCRIPTION
# Motivation and Context
We are attempting to investigate and fix an intermittent failure of the acceptance tests in CI and Latest, in the pipeline. It was discovered that the file contents have been changing on the FTP server, for the same filename, but further diagnosis has not been possible because the logs were full of lots of "not doing anything" useless log.

# What has changed
Removed useless log line.

# How to test?
Run the actionexporter and check it's not logging "not doing anything" all the time.

# Links
Trello: https://trello.com/c/MLoPHcVk/402-bug-check-for-iac-code-in-sftp-file-intermittently-causes-ats-to-fail