### PR TITLE
Bump common framework version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>uk.gov.ons.ctp.common</groupId>
             <artifactId>framework</artifactId>
-            <version>10.49.17</version>
+            <version>10.49.18</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
# Motivation and Context
We are seeing strange dates being returned by the Java Spring Boot REST APIs when there is a concurrency of 3 or 4 users hammering the endpoints. The dates are sometimes completely bogus (e.g. 30 February or 31 April). This is bad.

# What has changed
Updated rm-common-service so it they no longer uses `static` instances of a DateFormat object shared across threads which is *not thread safe*. The new version of rm-common-service is `10.49.18`.

# How to test?
Bug can be reproduced by hammering collex events endpoint (e.g. `http://[host]:[port]/collectionexercises/[collex id]>/events`) and checking to make sure that a date such as the `exercise_end` date is *always* being returned as the expected correct value. This bug only occurs when there are *multiple concurrent users*.

# Links
Trello: https://trello.com/c/bGt4TX2Q/405-bug-dates