### PR TITLE
Fix SFTP failure handling

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/SftpServicePublisher.java
@@ -13,7 +13,6 @@ import org.springframework.integration.file.FileHeaders;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
 import uk.gov.ons.ctp.response.action.export.domain.ExportFile;
@@ -81,16 +80,13 @@ public class SftpServicePublisher {
 
   @SuppressWarnings("unchecked")
   @ServiceActivator(inputChannel = "sftpFailedProcess")
-  public void sftpFailedProcess(ErrorMessage message) {
-    MessageHeaders headers =
-        ((MessagingException) message.getPayload()).getFailedMessage().getHeaders();
+  public void sftpFailedProcess(GenericMessage message) {
+    MessagingException payload = (MessagingException) message.getPayload();
+    MessageHeaders headers = payload.getFailedMessage().getHeaders();
     String fileName = (String) headers.get(FileHeaders.REMOTE_FILE);
     int actionCount = Integer.valueOf((String) headers.get(ACTION_COUNT));
 
-    log.with("file_name", fileName)
-        .with("action_count", actionCount)
-        .with("payload", message.getPayload())
-        .error("Sftp transfer failed");
+    log.with("file_name", fileName).with("action_count", actionCount).error("Sftp transfer failed");
 
     ExportFile exportFile = exportFileRepository.findOneByFilename(fileName);
     exportFile.setStatus(SendStatus.FAILED);

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
@@ -36,7 +36,8 @@ public class ExportScheduler {
     try {
       processExport();
     } catch (Exception ex) {
-      log.error("Uncaught exception - transaction rolled back and scheduled job will re-run", ex);
+      log.error(
+          "Uncaught exception - transaction rolled back. Will re-run when scheduled by cron", ex);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportScheduler.java
@@ -37,7 +37,6 @@ public class ExportScheduler {
       processExport();
     } catch (Exception ex) {
       log.error("Uncaught exception - transaction rolled back and scheduled job will re-run", ex);
-      throw ex;
     }
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportSchedulerTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/scheduled/ExportSchedulerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.response.action.export.scheduled;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -52,7 +51,6 @@ public class ExportSchedulerTest {
   public void shouldUnlockWhenExceptionThrown() throws InterruptedException {
     RLock mockLock = mock(RLock.class);
     DataGrid mockDataGrid = mock(DataGrid.class);
-    boolean exceptionThrown = false;
 
     // Given
     given(redissonClient.getFairLock(any())).willReturn(mockLock);
@@ -61,17 +59,12 @@ public class ExportSchedulerTest {
     doThrow(RuntimeException.class).when(exportProcessor).processExport();
 
     // When
-    try {
-      exportScheduler.scheduleExport();
-    } catch (Exception ex) {
-      exceptionThrown = true;
-    }
+    exportScheduler.scheduleExport();
 
     // Verify
     InOrder inOrder = inOrder(mockLock, exportProcessor);
     inOrder.verify(mockLock).tryLock(anyLong(), any(TimeUnit.class));
     inOrder.verify(exportProcessor).processExport();
     inOrder.verify(mockLock).unlock();
-    assertThat(exceptionThrown).isTrue();
   }
 }


### PR DESCRIPTION
# Motivation and Context
Action Exporter was not correctly wired up with Spring Integration to handle SFTP failures. Failures were resulting in exceptions being thrown by Spring, complaining that it couldn't find the error handler method. @davidmort searched the production logs, and thankfully this bug hasn't happened in prod [yet] during the time we've had Splunk, although it's possible that the error wasn't showing up because it wasn't being properly logged - it was spotted in _console output_ by chance.

# What has changed
Changed the method signature of `sftpFailedProcess` so that it matches what the SpEL expression expects to find. Refactored to pull the message headers out of the failed message correctly, so we know which file failed to send via SFTP.

# How to test?
Stop the SFTP server and try running a test which would cause the Action Exporter to attempt to create and send a file (e.g. `notification_letter.feature`) and you should see `Sftp transfer failed` in the logs, instead of a massive stack trace due to a Spring Integration wiring problem.

# Links
Trello: https://trello.com/c/B6ULaQVb/455-bug-action-exporter-does-not-handle-sftp-failures-correctly