### PR TITLE
Automate census docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag actionexportersvc "${DOCKER_GCP_LOCATION}"/actionexportersvc;
   docker push "${DOCKER_GCP_LOCATION}"/actionexportersvc;
@@ -36,4 +36,5 @@ cache:
 
 branches:
   only:
-  - rm-census
+    - rm-census
+    - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,4 @@ cache:
 
 branches:
   only:
-    - rm-census
     - automate-census-docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
   docker push "$DESTINATION_IMAGE_NAME";
@@ -34,4 +34,4 @@ cache:
 
 branches:
   only:
-    - automate-census-docker-build
+    - rm-census

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ language: java
 jdk: openjdk8
 
 env:
-  - SOURCE_IMAGE_NAME="actionexportersvc" DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-actionexportersvc"
+  global:
+    - SOURCE_IMAGE_NAME="actionexportersvc"
+    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-actionexportersvc"
 
 before_install:
 - mkdir -p ~/Documents/sftp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
 language: java
 jdk: openjdk8
 
+env:
+  - SOURCE_IMAGE_NAME="actionexportersvc" DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-actionexportersvc"
+
 before_install:
 - mkdir -p ~/Documents/sftp
 - cp .maven.settings.xml "$HOME"/.m2/settings.xml
@@ -18,8 +21,8 @@ script: mvn verify cobertura:cobertura-integration-test
 after_success:
 - if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker tag actionexportersvc "${DOCKER_GCP_LOCATION}"/actionexportersvc;
-  docker push "${DOCKER_GCP_LOCATION}"/actionexportersvc;
+  docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
+  docker push "$DESTINATION_IMAGE_NAME";
   fi
 - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,6 @@ after_success:
   fi
 - bash <(curl -s https://codecov.io/bash)
 
-notifications:
-  slack:
-    rooms:
-      secure: KRc+o003grFrMQpD73WoB4uQ6nyu/hFwUY3p2DyorEXd12Ms4c3adGYBIKrn/XoWYu40g7avvb+IKY8HzyT9Hm8+4wDOartk0a/gmO/ZvzLxCp63S/lWW4cX13kydgWE3tk7J6PrPP5Ps6UVLb4zVjXeeg3nalxKUCbHLfeyXW+vZFhANw5XiMDOSLuc9SEP3w/rsgBgwBfzpj0pM1fEJCQ0ZZoaAplvn0lFkdTiAyhtKGYHo/xSod7O4VwAfApUXUV8ABMwVFkaM3rGlIVDtoSZAH9eEwt3n9uPEr0jzJQovfVvV6oikaDVI2bX9iwnt9Cb38fCmN0iQtEyKl5P4syZy8zw19wA6GjEz7CS/xLIc8wHHIuBGqJZ5sTWQ+Ggzlbo2hd8geZaqpXiouHgqiABmtX1J6Dii9BYdZntXSMBFR+iCGFuueSeCrw5TBuH9EwoPRMAPYY20y/y51bAXKBzd3ScapJ/6edr4/qxhKX6Z/sFJcr54YZHOA/1czbdIKt5Ass2/kQxp2uzu/mmVeG+wjtxmM7iex2J0ldE+SkdlDodg99/byTOOy2kA4TmfXUyc6UI9H4dXJhsp1jA52q302O2M0dSMS8la7LZ6n4w3x4IvUMLyJgxohJykwHLTkwEWc0ERp6YBb1YlO3FUA8QWFvQ2F6couhx0SQhLA0=
-    on_failure: never
-    on_success: never
-
 cache:
   directories:
   - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]); then
+- if ([ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]) || ([ "$TRAVIS_BRANCH" == "automate-census-docker-build" ]); then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag actionexportersvc "${DOCKER_GCP_LOCATION}"/actionexportersvc;
   docker push "${DOCKER_GCP_LOCATION}"/actionexportersvc;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ install: mvn install -DskipTests -DskipITs -Ddocker.skip -Ddockerfile.skip -Dmav
 script: mvn verify cobertura:cobertura-integration-test
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-  docker push sdcplatform/actionexportersvc;
+- if [ "$TRAVIS_BRANCH" == "rm-census" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
+  docker tag actionexportersvc "${DOCKER_GCP_LOCATION}"/actionexportersvc;
+  docker push "${DOCKER_GCP_LOCATION}"/actionexportersvc;
   fi
 - bash <(curl -s https://codecov.io/bash)
 
@@ -26,7 +27,7 @@ notifications:
   slack:
     rooms:
       secure: KRc+o003grFrMQpD73WoB4uQ6nyu/hFwUY3p2DyorEXd12Ms4c3adGYBIKrn/XoWYu40g7avvb+IKY8HzyT9Hm8+4wDOartk0a/gmO/ZvzLxCp63S/lWW4cX13kydgWE3tk7J6PrPP5Ps6UVLb4zVjXeeg3nalxKUCbHLfeyXW+vZFhANw5XiMDOSLuc9SEP3w/rsgBgwBfzpj0pM1fEJCQ0ZZoaAplvn0lFkdTiAyhtKGYHo/xSod7O4VwAfApUXUV8ABMwVFkaM3rGlIVDtoSZAH9eEwt3n9uPEr0jzJQovfVvV6oikaDVI2bX9iwnt9Cb38fCmN0iQtEyKl5P4syZy8zw19wA6GjEz7CS/xLIc8wHHIuBGqJZ5sTWQ+Ggzlbo2hd8geZaqpXiouHgqiABmtX1J6Dii9BYdZntXSMBFR+iCGFuueSeCrw5TBuH9EwoPRMAPYY20y/y51bAXKBzd3ScapJ/6edr4/qxhKX6Z/sFJcr54YZHOA/1czbdIKt5Ass2/kQxp2uzu/mmVeG+wjtxmM7iex2J0ldE+SkdlDodg99/byTOOy2kA4TmfXUyc6UI9H4dXJhsp1jA52q302O2M0dSMS8la7LZ6n4w3x4IvUMLyJgxohJykwHLTkwEWc0ERp6YBb1YlO3FUA8QWFvQ2F6couhx0SQhLA0=
-    on_failure: always
+    on_failure: never
     on_success: never
 
 cache:
@@ -35,4 +36,4 @@ cache:
 
 branches:
   only:
-  - master
+  - rm-census

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <repository>sdcplatform/${project.artifactId}</repository>
+                            <repository>${project.artifactId}</repository>
                             <buildArgs>
                                 <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
                             </buildArgs>


### PR DESCRIPTION
# Motivation and Context
We want travis build to push docker images to Google Container Registry instead of dockerhub

# What has changed
Replaced docker image prefix with GCR registry location
NOTE: before merge, remove "automate-census-docker-build" branch condition and "branches only" section in .travis.yml file

<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
From travis dashboard, switch to  "automate-census-docker-build" branch and "Restart Build". Once complete, check latest Docker image is in GCR.
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/dC6sEWqE/443-set-up-automated-docker-image-build)