### PR TITLE
Execute the Action Exporter service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM openjdk:8-jre-slim
 
 VOLUME /tmp
-ARG JAR_FILE=actionexportersvc-*.jar
+ARG JAR_FILE=actionexportersvc*.jar
 RUN apt-get update
-RUN apt-get -yq install curl
 RUN apt-get -yq clean
+
+RUN groupadd -g 989 actionexportersvc && \
+    useradd -r -u 989 -g actionexportersvc actionexportersvc
+USER actionexportersvc
+
 COPY target/$JAR_FILE /opt/actionexportersvc.jar
 
-ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -jar /opt/actionexportersvc.jar" ]
-
+ENTRYPOINT [ "java", "-jar", "/opt/actionexportersvc.jar" ]

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterBeanMapper.java
@@ -3,8 +3,6 @@ package uk.gov.ons.ctp.response.action;
 import ma.glasnost.orika.MapperFactory;
 import ma.glasnost.orika.converter.ConverterFactory;
 import ma.glasnost.orika.impl.ConfigurableMapper;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
-import ma.glasnost.orika.impl.generator.EclipseJdtCompilerStrategy;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.ctp.common.util.StringToUUIDConverter;
 import uk.gov.ons.ctp.response.action.export.domain.ActionRequestInstruction;
@@ -17,11 +15,6 @@ import uk.gov.ons.ctp.response.action.export.representation.TemplateMappingDTO;
 /** The bean mapper to go from Entity objects to Presentation objects. */
 @Component
 public class ActionExporterBeanMapper extends ConfigurableMapper {
-
-  @Override
-  public void configureFactoryBuilder(DefaultMapperFactory.Builder builder) {
-    builder.compilerStrategy(new EclipseJdtCompilerStrategy());
-  }
 
   /**
    * This method configures the bean mapper.


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The `ActionExporterBeanMapper` has been changed so the `configureFactoryBuilder` method is no longer overridden to specify the `EclipseJdtCompilerStrategy`. Detailed investigation revealed that using this compiler strategy causes Orika to try to write Java source files to a directory named `/file:` _at runtime_. This was failing during container start-up when running as a non-root user. Not overriding the method means Orika will use the default `JavassistCompilerStrategy`, which is what the other RM Java microservices use.

The Dockerfile has been changed:

* Create a dedicated non-root user account for executing the Java code
* The existing `ENTRYPOINT` command was poorly-formed:
  - The use of `sh -c` does not pass Unix signals to the Java process
  - When using the _exec_ form of `ENTRYPOINT` each argument should be its own array element
  - The `JAVA_OPTS` environment variable is Tomcat-specific and may be omitted. A separate PR linked below addresses passing options to the JVM via the standard `JAVA_TOOL_OPTIONS` environment variable

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Java process running as the expected non-root user account 

# Links
* https://docs.docker.com/engine/reference/builder/#entrypoint
* https://github.com/ONSdigital/census-rm-kubernetes/pull/14