### PR TITLE
Refactor export algorithm

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateMappingService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/TemplateMappingService.java
@@ -5,6 +5,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -52,9 +53,9 @@ public class TemplateMappingService {
     return repository.findAll();
   }
 
-  public Map<String, List<TemplateMapping>> retrieveAllTemplateMappingsByFilename() {
+  public Map<String, TemplateMapping> retrieveAllTemplateMappingsByActionType() {
     return retrieveAllTemplateMappings()
         .stream()
-        .collect(Collectors.groupingBy(TemplateMapping::getFileNamePrefix));
+        .collect(Collectors.toMap(TemplateMapping::getActionType, Function.identity()));
   }
 }

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -85,7 +85,7 @@ data-grid:
   list-time-to-live-seconds: 600
 
 export-schedule:
-  cron-expression: "0 * * * * ?"
+  cron-expression: "0 0/5 * 1/1 * ? *"
 
 sftp:
   directory: BSD/


### PR DESCRIPTION
# Motivation and Context
There's a cron job in Action Exporter with way too much computational complexity and some over the top data structures. This reduces both sets of nested loops to single loops, in one case entirely and in the other by using language features which should make it quicker. I also introduced a new Class to replace a Map of Maps of Lists, which should obviously be much easier to understand and hog less memory.

# What has changed
Refactored how the data was structured to remove nested loops in building the data structure