### PR TITLE
changed e-mail field character limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target
 *.data
 *.redo
 *.backup
+
+.vscode/

--- a/src/main/resources/database/changes/release-10.40.0/actionexporter_foundation_schema.sql
+++ b/src/main/resources/database/changes/release-10.40.0/actionexporter_foundation_schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE contact (
     forename 		character varying(35),
     surname 		character varying(35),
     phonenumber 	character varying(20),
-    emailaddress 	character varying(50),
+    emailaddress 	character varying(200),
     title 		character varying(20)
 );
 

--- a/src/main/resources/database/changes/release-17/changelog.yml
+++ b/src/main/resources/database/changes/release-17/changelog.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+
+  - changeSet:
+      id: 17-1
+      author: Adam Wilkie
+      changes:
+        - sqlFile:
+            comment: Change email field size to 200
+            path: update_email_field_size.sql
+            relativeToChangelogFile: true
+            splitStatements: false

--- a/src/main/resources/database/changes/release-17/update_email_field_size.sql
+++ b/src/main/resources/database/changes/release-17/update_email_field_size.sql
@@ -1,0 +1,2 @@
+-- Change email field length to 200
+ALTER TABLE ONLY actionexporter.contact ALTER COLUMN emailaddress varchar(200);

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
@@ -49,7 +49,6 @@ public class ActionRequestBuilder {
     actionRequest.setContact(new ActionContact());
     actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
     actionRequest.setReturnByDate(DateTimeFormatter.ofPattern("dd/MM").format(LocalDate.now()));
-
     actionRequest.getContact().setEmailAddress("this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
 
     return actionRequest;

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
@@ -49,7 +49,6 @@ public class ActionRequestBuilder {
     actionRequest.setContact(new ActionContact());
     actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
     actionRequest.setReturnByDate(DateTimeFormatter.ofPattern("dd/MM").format(LocalDate.now()));
-    actionRequest.getContact().setEmailAddress("this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
 
     return actionRequest;
   }

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
@@ -50,6 +50,8 @@ public class ActionRequestBuilder {
     actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
     actionRequest.setReturnByDate(DateTimeFormatter.ofPattern("dd/MM").format(LocalDate.now()));
 
+    actionRequest.getContact().setEmailAddress("this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
+
     return actionRequest;
   }
 

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
@@ -49,6 +49,10 @@ public class ActionRequestBuilder {
     actionRequest.setContact(new ActionContact());
     actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
     actionRequest.setReturnByDate(DateTimeFormatter.ofPattern("dd/MM").format(LocalDate.now()));
+    actionRequest
+      .getContact()
+      .setEmailAddress(
+          "this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
 
     return actionRequest;
   }


### PR DESCRIPTION
# Motivation and Context
The e-mail field in the action exporter schema needed to be changed from 50 to 200 in order to accommodate longer e-mails.

# What has changed

- The `emailaddress` field in `action exporter_foundation_schema.sql` was changed from allowing a maximum of 50 characters to a maximum of 200.

- A line was added into `ActionRequestBuilder.java` to make sure that the tests don't break from having a long e-mail address inserted onto them.

# How to test?
Build the service and make sure everything works.

# Links

[Trello card](https://trello.com/c/I75AHija)