### PR TITLE
Fix liquibase script for updating email length

### DIFF
--- a/src/main/resources/database/changelog-master.yml
+++ b/src/main/resources/database/changelog-master.yml
@@ -47,3 +47,7 @@ databaseChangeLog:
 
   - include:
       file: database/changes/release-16/changelog.yml
+
+  - include:
+      file: database/changes/release-17/changelog.yml
+

--- a/src/main/resources/database/changes/release-10.40.0/actionexporter_foundation_schema.sql
+++ b/src/main/resources/database/changes/release-10.40.0/actionexporter_foundation_schema.sql
@@ -79,7 +79,7 @@ CREATE TABLE contact (
     forename 		character varying(35),
     surname 		character varying(35),
     phonenumber 	character varying(20),
-    emailaddress 	character varying(200),
+    emailaddress 	character varying(50),
     title 		character varying(20)
 );
 

--- a/src/main/resources/database/changes/release-17/update_email_field_size.sql
+++ b/src/main/resources/database/changes/release-17/update_email_field_size.sql
@@ -1,2 +1,2 @@
 -- Change email field length to 200
-ALTER TABLE ONLY actionexporter.contact ALTER COLUMN emailaddress varchar(200);
+ALTER TABLE ONLY actionexporter.contact ALTER COLUMN emailaddress TYPE varchar (200);

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/utility/ActionRequestBuilder.java
@@ -50,9 +50,9 @@ public class ActionRequestBuilder {
     actionRequest.setEvents(new ActionEvent(Collections.singletonList("event1")));
     actionRequest.setReturnByDate(DateTimeFormatter.ofPattern("dd/MM").format(LocalDate.now()));
     actionRequest
-      .getContact()
-      .setEmailAddress(
-          "this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
+        .getContact()
+        .setEmailAddress(
+            "this_email_is_very_long_and_should_hopefully_exceed_more_than_fifty_characters@gmail.com");
 
     return actionRequest;
   }


### PR DESCRIPTION
# Motivation and Context
Fixing a few minor mistakes in https://github.com/ONSdigital/rm-actionexporter-service/pull/75

1. The master change log was not updated so liquibase would not know to run the update script.
1. The alter table statement was slightly incorrect, for postgres it requires the type keyword
1. The foundation script which originally created the table should not have been modified

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
