### PR TITLE
Upload SFTP generated file to GCP

### DIFF
--- a/_infra/helm/action-exporter/Chart.yaml
+++ b/_infra/helm/action-exporter/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.0.5
+appVersion: 12.0.6

--- a/_infra/helm/action-exporter/templates/deployment.yaml
+++ b/_infra/helm/action-exporter/templates/deployment.yaml
@@ -241,5 +241,10 @@ spec:
             value: "DEBUG"
           - name: EXPORT_SCHEDULE_CRON_EXPRESSION
             value: {{ .Values.exportSchedule.cron | quote }}
+          - name: GCS_ENABLED
+            value: "{{ .Values.gcs.enabled }}"
+          - name: GCS_BUCKET
+            value: "{{ .Values.gcs.bucket }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+

--- a/_infra/helm/action-exporter/values.yaml
+++ b/_infra/helm/action-exporter/values.yaml
@@ -44,3 +44,7 @@ sftp:
 
 managedRabbitMQ:
   enabled: false
+
+gcs:
+  bucket: "example"
+  enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <version>1.108.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
             <version>2.7.0</version>

--- a/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/ActionExporterApplication.java
@@ -1,6 +1,8 @@
 package uk.gov.ons.ctp.response.action;
 
 import com.godaddy.logging.LoggingConfigs;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import java.time.Clock;
 import javax.annotation.PostConstruct;
 import net.sourceforge.cobertura.CoverageIgnore;
@@ -83,6 +85,16 @@ public class ActionExporterApplication {
   @Bean
   public Clock clock() {
     return Clock.systemDefaultZone();
+  }
+
+  /**
+   * Bean used to create and configure GCS Client
+   *
+   * @return the Storage Client
+   */
+  @Bean
+  public Storage storage() {
+    return StorageOptions.getDefaultInstance().getService();
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
@@ -17,4 +17,5 @@ public class AppConfig {
   private DataGrid dataGrid;
   private SwaggerSettings swaggerSettings;
   private Logging logging;
+  private GCS gcs;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/config/GCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/config/GCS.java
@@ -1,0 +1,12 @@
+package uk.gov.ons.ctp.response.action.export.config;
+
+import lombok.Data;
+import net.sourceforge.cobertura.CoverageIgnore;
+
+/** Config POJO for GCS params */
+@CoverageIgnore
+@Data
+public class GCS {
+  private String bucket;
+  private boolean enabled;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -1,0 +1,34 @@
+package uk.gov.ons.ctp.response.action.export.message;
+
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import com.google.cloud.storage.*;
+import java.io.ByteArrayOutputStream;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UploadObjectGCS {
+  private static final Logger log = LoggerFactory.getLogger(UploadObjectGCS.class);
+  private final Storage storage;
+
+  public UploadObjectGCS(Storage storage) {
+    this.storage = storage;
+  }
+
+  public boolean uploadObject(String filename, String bucket, ByteArrayOutputStream data) {
+    BlobId blobId = BlobId.of(bucket, filename);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    Boolean isSuccess = false;
+    log.with("file_name", filename).with("bucket", bucket).info("Uploading to GCS bucket");
+    try {
+      storage.create(blobInfo, data.toByteArray());
+      isSuccess = true;
+      log.with("file_name", filename).with("bucket", bucket).info("Upload Successful!");
+    } catch (StorageException exception) {
+      log.with("exception", exception)
+          .with("file_name", filename)
+          .error("Error uploading the generated file to GCS");
+    }
+    return isSuccess;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
@@ -6,10 +6,12 @@ import java.io.ByteArrayOutputStream;
 import java.text.SimpleDateFormat;
 import java.time.Clock;
 import org.springframework.stereotype.Service;
+import uk.gov.ons.ctp.response.action.export.config.AppConfig;
 import uk.gov.ons.ctp.response.action.export.domain.ExportFile;
 import uk.gov.ons.ctp.response.action.export.domain.ExportJob;
 import uk.gov.ons.ctp.response.action.export.message.EventPublisher;
 import uk.gov.ons.ctp.response.action.export.message.SftpServicePublisher;
+import uk.gov.ons.ctp.response.action.export.message.UploadObjectGCS;
 import uk.gov.ons.ctp.response.action.export.repository.ExportFileRepository;
 
 @Service
@@ -28,15 +30,23 @@ public class NotificationFileCreator {
 
   private final Clock clock;
 
+  private final UploadObjectGCS uploadObjectGCS;
+
+  private final AppConfig appConfig;
+
   public NotificationFileCreator(
       SftpServicePublisher sftpService,
       EventPublisher eventPublisher,
       ExportFileRepository exportFileRepository,
-      Clock clock) {
+      Clock clock,
+      UploadObjectGCS uploadObjectGCS,
+      AppConfig appConfig) {
     this.sftpService = sftpService;
     this.eventPublisher = eventPublisher;
     this.exportFileRepository = exportFileRepository;
     this.clock = clock;
+    this.uploadObjectGCS = uploadObjectGCS;
+    this.appConfig = appConfig;
   }
 
   public void uploadData(
@@ -67,6 +77,12 @@ public class NotificationFileCreator {
     exportFile.setFilename(filename);
     exportFileRepository.saveAndFlush(exportFile);
 
+    boolean isEnabled = appConfig.getGcs().isEnabled();
+    if (isEnabled) {
+      String bucket = appConfig.getGcs().getBucket();
+      uploadObjectGCS.uploadObject(filename, bucket, data);
+      log.with("bucket", bucket).info("File Uploaded to bucket.");
+    }
     sftpService.sendMessage(filename, responseRequiredList, Integer.toString(actionCount), data);
 
     eventPublisher.publishEvent("Printed file " + filename);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,6 +10,10 @@ spring:
     password: postgres
     port: 16432
 
+gcs:
+  bucket: "bucket"
+  enabled: false
+
 sftp:
   port: 1122
   host: localhost

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,3 +130,7 @@ swagger-settings:
   title: Action Exporter API
   description: API for ${project.artifactId}
   version: ${project.version}
+
+gcs:
+  bucket: "bucket"
+  enabled: false

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCSTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCSTest.java
@@ -1,0 +1,45 @@
+package uk.gov.ons.ctp.response.action.export.message;
+
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.*;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UploadObjectGCSTest {
+
+    @Mock private Storage storage;
+    @InjectMocks private UploadObjectGCS uploadObjectGCS;
+
+    @Test
+    public void shouldUploadFileToGCS() {
+        ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
+        String bucket = "testBucket";
+        String filename = "testFile.csv";
+        boolean actualResponse = uploadObjectGCS.uploadObject(filename,bucket,mockFile);
+        Assert.assertTrue(actualResponse);
+    }
+    @Test
+    public void shouldErrorOutWhileUploadToGCS() {
+        ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
+        String bucket = "testBucket";
+        String filename = "testFile.csv";
+        BlobId blobId = BlobId.of(bucket, filename);
+        BlobInfo mockBlobInfo = BlobInfo.newBuilder(blobId).build();
+        Blob blob = mock(Blob.class);
+        when(storage.create(mockBlobInfo, mockFile.toByteArray())).thenThrow(StorageException.class);
+        boolean actualResponse = uploadObjectGCS.uploadObject(filename,bucket,mockFile);
+        Assert.assertFalse(actualResponse);
+    }
+}

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCSTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCSTest.java
@@ -1,45 +1,41 @@
 package uk.gov.ons.ctp.response.action.export.message;
 
-import com.google.cloud.WriteChannel;
+import static org.mockito.Mockito.*;
+
 import com.google.cloud.storage.*;
+import java.io.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-
-import java.io.ByteArrayOutputStream;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UploadObjectGCSTest {
 
-    @Mock private Storage storage;
-    @InjectMocks private UploadObjectGCS uploadObjectGCS;
+  @Mock private Storage storage;
+  @InjectMocks private UploadObjectGCS uploadObjectGCS;
 
-    @Test
-    public void shouldUploadFileToGCS() {
-        ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
-        String bucket = "testBucket";
-        String filename = "testFile.csv";
-        boolean actualResponse = uploadObjectGCS.uploadObject(filename,bucket,mockFile);
-        Assert.assertTrue(actualResponse);
-    }
-    @Test
-    public void shouldErrorOutWhileUploadToGCS() {
-        ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
-        String bucket = "testBucket";
-        String filename = "testFile.csv";
-        BlobId blobId = BlobId.of(bucket, filename);
-        BlobInfo mockBlobInfo = BlobInfo.newBuilder(blobId).build();
-        Blob blob = mock(Blob.class);
-        when(storage.create(mockBlobInfo, mockFile.toByteArray())).thenThrow(StorageException.class);
-        boolean actualResponse = uploadObjectGCS.uploadObject(filename,bucket,mockFile);
-        Assert.assertFalse(actualResponse);
-    }
+  @Test
+  public void shouldUploadFileToGCS() {
+    ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
+    String bucket = "testBucket";
+    String filename = "testFile.csv";
+    boolean actualResponse = uploadObjectGCS.uploadObject(filename, bucket, mockFile);
+    Assert.assertTrue(actualResponse);
+  }
+
+  @Test
+  public void shouldErrorOutWhileUploadToGCS() {
+    ByteArrayOutputStream mockFile = new ByteArrayOutputStream();
+    String bucket = "testBucket";
+    String filename = "testFile.csv";
+    BlobId blobId = BlobId.of(bucket, filename);
+    BlobInfo mockBlobInfo = BlobInfo.newBuilder(blobId).build();
+    Blob blob = mock(Blob.class);
+    when(storage.create(mockBlobInfo, mockFile.toByteArray())).thenThrow(StorageException.class);
+    boolean actualResponse = uploadObjectGCS.uploadObject(filename, bucket, mockFile);
+    Assert.assertFalse(actualResponse);
+  }
 }


### PR DESCRIPTION
To Upload the generate sftp file to GCS.
This change will upload the generated file to the gcs bucket making use of the default compute service account, hence appropriate role need to be provided to the service account.
The deployment will also require to provide the updated configuration with the gcs enabled as true and bucket name.