### PR TITLE
Fix delete record bug

### DIFF
--- a/_infra/helm/action-exporter/Chart.yaml
+++ b/_infra/helm/action-exporter/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.3.5
+appVersion: 12.3.6


### PR DESCRIPTION
# Motivation and Context
There was a bug in the deletion where an exportjobId can have actionInstructions with the id but not a corresponding exportfile.  This could be due to manually deleting the exportfile as an example, as in the normal flow of operations, an exportjobid will usually have both 1 or more exportFiles associated with it and 1 or more actionRequestInstructions.

This change checks if that number is 0, and if it is, just deletes all the actionRequestInstructions with that ExportJobId as they won't be used by anything ever again and have essentially been orphaned.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
