### PR TITLE
Reworking to push to print file data to a gcs bucket

### DIFF
--- a/_infra/helm/action-exporter/Chart.yaml
+++ b/_infra/helm/action-exporter/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 12.4.0
+appVersion: 12.4.1

--- a/_infra/helm/action-exporter/templates/deployment.yaml
+++ b/_infra/helm/action-exporter/templates/deployment.yaml
@@ -194,6 +194,10 @@ spec:
             value: "{{ .Values.gcp.project }}"
           - name: GCP_TOPIC
             value: "{{ .Values.gcp.topic }}"
+          - name: GCS_ENABLED
+            value: "{{ .Values.gcs.enabled }}"
+          - name: GCS_BUCKET
+            value: "{{ .Values.gcs.bucket }}"
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/secrets/google/credentials.json
           resources:

--- a/_infra/helm/action-exporter/values.yaml
+++ b/_infra/helm/action-exporter/values.yaml
@@ -48,6 +48,9 @@ resources:
 managedRabbitMQ:
   enabled: false
 
+gcs:
+  bucket: "ras-rm-print-file"
+
 gcp:
   project: ras-rm-sandbox
   topic: print-file-jobs

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/config/AppConfig.java
@@ -12,4 +12,5 @@ import uk.gov.ons.ctp.common.message.rabbit.Rabbitmq;
 public class AppConfig {
   private Rabbitmq rabbitmq;
   private Logging logging;
+  private GCS gcs;
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/config/GCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/config/GCS.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.ctp.response.action.export.config;
+
+import lombok.Data;
+
+/** Config POJO for GCS params */
+@Data
+public class GCS {
+  private String bucket;
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -22,10 +22,15 @@ public class UploadObjectGCS {
     try {
       storage.create(blobInfo, data);
       isSuccess = true;
-      log.info("file_name: "+ filename + " bucket: " + bucket + ", Upload Successful!");
+      log.info("file_name: " + filename + " bucket: " + bucket + ", Upload Successful!");
     } catch (StorageException exception) {
       log.error(
-          "file_name: " + filename  + " bucket: " + bucket + ", Error uploading the generated file to GCS", exception);
+          "file_name: "
+              + filename
+              + " bucket: "
+              + bucket
+              + ", Error uploading the generated file to GCS",
+          exception);
     }
     return isSuccess;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -25,11 +25,7 @@ public class UploadObjectGCS {
       log.info("file_name: ", filename + "bucket: " + bucket + ", Upload Successful!");
     } catch (StorageException exception) {
       log.error(
-          "exception:"
-              + exception
-              + ", file_name: "
-              + filename
-              + ", Error uploading the generated file to GCS");
+          "file_name: " + filename + ", Error uploading the generated file to GCS", exception);
     }
     return isSuccess;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -16,7 +16,7 @@ public class UploadObjectGCS {
 
   public boolean uploadObject(String filename, String bucket, byte[] data) {
     BlobId blobId = BlobId.of(bucket, filename);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("application/json").build();
     Boolean isSuccess = false;
     log.info("file_name: ", filename + "bucket: " + bucket + ", Uploading to GCS bucket");
     try {

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -1,0 +1,36 @@
+package uk.gov.ons.ctp.response.action.export.message;
+
+import com.google.cloud.storage.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UploadObjectGCS {
+  private static final Logger log = LoggerFactory.getLogger(UploadObjectGCS.class);
+  private final Storage storage;
+
+  public UploadObjectGCS(Storage storage) {
+    this.storage = storage;
+  }
+
+  public boolean uploadObject(String filename, String bucket, byte[] data) {
+    BlobId blobId = BlobId.of(bucket, filename);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    Boolean isSuccess = false;
+    log.info("file_name: ", filename + "bucket: " + bucket + ", Uploading to GCS bucket");
+    try {
+      storage.create(blobInfo, data);
+      isSuccess = true;
+      log.info("file_name: ", filename + "bucket: " + bucket + ", Upload Successful!");
+    } catch (StorageException exception) {
+      log.error(
+          "exception:"
+              + exception
+              + ", file_name: "
+              + filename
+              + ", Error uploading the generated file to GCS");
+    }
+    return isSuccess;
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/message/UploadObjectGCS.java
@@ -18,14 +18,14 @@ public class UploadObjectGCS {
     BlobId blobId = BlobId.of(bucket, filename);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("application/json").build();
     Boolean isSuccess = false;
-    log.info("file_name: ", filename + "bucket: " + bucket + ", Uploading to GCS bucket");
+    log.info("file_name: ", filename + " bucket: " + bucket + ", Uploading to GCS bucket");
     try {
       storage.create(blobInfo, data);
       isSuccess = true;
-      log.info("file_name: ", filename + "bucket: " + bucket + ", Upload Successful!");
+      log.info("file_name: "+ filename + " bucket: " + bucket + ", Upload Successful!");
     } catch (StorageException exception) {
       log.error(
-          "file_name: " + filename + ", Error uploading the generated file to GCS", exception);
+          "file_name: " + filename  + " bucket: " + bucket + ", Error uploading the generated file to GCS", exception);
     }
     return isSuccess;
   }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
@@ -57,9 +57,9 @@ public class NotificationFileCreator {
 
     // temporarily hook in here as at this point we know the name of the file
     // and all the action request instructions
-    boolean sucess = printFileService.send(filename, actionRequestInstructions);
+    boolean success = printFileService.send(filename, actionRequestInstructions);
 
-    if (sucess) {
+    if (success) {
       ExportFile exportFile = new ExportFile();
       exportFile.setExportJobId(exportJob.getId());
       exportFile.setFilename(filename);

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreator.java
@@ -55,13 +55,15 @@ public class NotificationFileCreator {
 
     log.info("filename: " + filename + ", uploading file");
 
-    ExportFile exportFile = new ExportFile();
-    exportFile.setExportJobId(exportJob.getId());
-    exportFile.setFilename(filename);
-    exportFileRepository.saveAndFlush(exportFile);
-
     // temporarily hook in here as at this point we know the name of the file
     // and all the action request instructions
-    printFileService.send(filename, actionRequestInstructions);
+    boolean sucess = printFileService.send(filename, actionRequestInstructions);
+
+    if (sucess) {
+      ExportFile exportFile = new ExportFile();
+      exportFile.setExportJobId(exportJob.getId());
+      exportFile.setFilename(filename);
+      exportFileRepository.saveAndFlush(exportFile);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
@@ -35,14 +35,13 @@ public class PrintFileService {
 
     List<PrintFileEntry> printFile = convertToPrintFile(actionRequestInstructions);
     try {
+      log.debug("creating json representation of print file");
       String json = createJsonRepresentation(printFile);
-      log.info("json");
-
       ByteString data = ByteString.copyFromUtf8(json);
 
       String bucket = appConfig.getGcs().getBucket();
+      log.info(" about to uploaded to bucket " + bucket);
       uploadObjectGCS.uploadObject(dataFilename, bucket, data.toByteArray());
-      log.info("bucket: " + bucket + ", file " + dataFilename + " uploaded to bucket.");
 
       ByteString pubsubData = ByteString.copyFromUtf8(dataFilename);
 
@@ -55,8 +54,7 @@ public class PrintFileService {
       ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
       String messageId = messageIdFuture.get();
       log.debug("messageId: " + messageId);
-      log.debug("print file pubsub sent sucessfully");
-      log.info(json);
+      log.debug("print file pubsub successfully sent with messageId:" + messageId);
     } catch (JsonProcessingException e) {
       log.error("unable to convert to json", e);
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
@@ -41,7 +41,7 @@ public class PrintFileService {
       ByteString data = ByteString.copyFromUtf8(json);
 
       String bucket = appConfig.getGcs().getBucket();
-      log.info(" about to uploaded to bucket " + bucket);
+      log.info("about to uploaded to bucket " + bucket);
       boolean uploaded = uploadObjectGCS.uploadObject(dataFilename, bucket, data.toByteArray());
 
       if (uploaded) {
@@ -55,8 +55,7 @@ public class PrintFileService {
 
         ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
         String messageId = messageIdFuture.get();
-        log.debug("messageId: " + messageId);
-        log.debug("print file pubsub successfully sent with messageId:" + messageId);
+        log.info("print file pubsub successfully sent with messageId:" + messageId);
         success = true;
       }
     } catch (JsonProcessingException e) {

--- a/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
+++ b/src/main/java/uk/gov/ons/ctp/response/action/export/service/PrintFileService.java
@@ -50,7 +50,7 @@ public class PrintFileService {
         PubsubMessage pubsubMessage =
             PubsubMessage.newBuilder()
                 .setData(pubsubData)
-                .putAttributes("filename", printFilename)
+                .putAttributes("printFilename", printFilename)
                 .build();
 
         ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);

--- a/src/test/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreatorTest.java
+++ b/src/test/java/uk/gov/ons/ctp/response/action/export/service/NotificationFileCreatorTest.java
@@ -51,13 +51,14 @@ public class NotificationFileCreatorTest {
     Date now = new Date();
 
     // Given
+    String expectedFilename = String.format("BSNOT_%s.csv", FILENAME_DATE_FORMAT.format(now));
     given(clock.millis()).willReturn(now.getTime());
+    given(printFileService.send(expectedFilename, actionRequestInstructions)).willReturn(true);
 
     // When
     notificationFileCreator.uploadData("BSNOT", actionRequestInstructions, exportJob);
 
     // Then
-    String expectedFilename = String.format("BSNOT_%s.csv", FILENAME_DATE_FORMAT.format(now));
     ArgumentCaptor<ExportFile> exportFileArgumentCaptor = ArgumentCaptor.forClass(ExportFile.class);
     verify(exportFileRepository).saveAndFlush(exportFileArgumentCaptor.capture());
     assertThat(exportFileArgumentCaptor.getValue().getFilename()).isEqualTo(expectedFilename);


### PR DESCRIPTION
Due to the limitation on size for both data store and pubsub the data transfer between action exporter and print file will be done via a GCS bucket.

Action exporter will write the data file to GCS and then publish a message to pubsub with the name of the datafile in it. Print file will then read that file and use the data for templating.